### PR TITLE
Bump hono, ajv for security. Remove health check and add URL validation for callback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.10 AS base
+FROM node:22.22 AS base
 
 USER node
 WORKDIR /opt/api

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,4 @@ USER node
 WORKDIR /opt/api
 RUN npm ci --omit=dev
 COPY --chown=node:node --from=builder /opt/api/build ./build
-
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD node -e "fetch('http://localhost:9595/health').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"
-
 ENTRYPOINT [ "npm", "run", "start" ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -371,9 +371,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1048,9 +1048,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.8.tgz",
-      "integrity": "sha512-eVkB/CYCCei7K2WElZW9yYQFWssG0DhaDhVvr7wy5jJ22K+ck8fWW0EsLpB0sITUTvPnc97+rrbQqIr5iqiy9Q==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.0.tgz",
+      "integrity": "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/src/v1/controllers/flights/flightInstallController.ts
+++ b/src/v1/controllers/flights/flightInstallController.ts
@@ -25,7 +25,7 @@ const flightInstallController: RequestHandler = async (req, res): Promise<void> 
 
   const allowedHosts = new Set(['usetrmnl.com', 'www.usetrmnl.com', 'trmnl.com', 'www.trmnl.com'])
 
-  if (!allowedHosts.has(url.hostname)) {
+  if (!allowedHosts.has(url.hostname) || url.protocol !== 'https:') {
     res.status(400).json({ error: 'Bad Request', message: 'Invalid callback URL' })
     return
   }
@@ -70,8 +70,8 @@ const flightInstallController: RequestHandler = async (req, res): Promise<void> 
   logger.debug(hash)
   await storeTrmnlToken(hash)
 
-  logger.debug('[TRMNL] Redirecting user back to', callback)
-  res.redirect(callback)
+  logger.debug('[TRMNL] Redirecting user back to', url.toString())
+  res.redirect(url.toString())
   return
 }
 

--- a/src/v1/controllers/metro/trmnlInstallController.ts
+++ b/src/v1/controllers/metro/trmnlInstallController.ts
@@ -28,7 +28,7 @@ const trmnlInstallController: RequestHandler = async (req, res): Promise<void> =
   // Just in case, make sure we only permit callback urls set to trmnl.com domain
   const allowedHosts = new Set(['usetrmnl.com', 'www.usetrmnl.com', 'trmnl.com', 'www.trmnl.com'])
 
-  if (!allowedHosts.has(url.hostname)) {
+  if (!allowedHosts.has(url.hostname) || url.protocol !== 'https:') {
     res.status(400).json({ error: 'Bad Request', message: 'Invalid callback URL' })
     return
   }
@@ -74,8 +74,8 @@ const trmnlInstallController: RequestHandler = async (req, res): Promise<void> =
   logger.debug(hash)
   await storeTrmnlToken(hash)
 
-  logger.debug('[TRMNL] Redirecting user back to', callback)
-  res.redirect(callback)
+  logger.debug('[TRMNL] Redirecting user back to', url.toString())
+  res.redirect(url.toString())
   return
 }
 


### PR DESCRIPTION
PR bumps hono, ajv package versions
Also bumps base NodeJS version from 22.10 to 22.22
Added so that the install controllers use the validated URL variable instead of callback only