### PR TITLE
Add configurable AeroDataBox provider (api.market default, RapidAPI fallback)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -41,5 +41,6 @@ export const config = {
     },
     aerodatabox: {
         apiKey:         process.env.AERODATABOX_API_KEY ?? '',
+        provider:       (process.env.AERODATABOX_PROVIDER ?? 'apimarket') as 'apimarket' | 'rapidapi',
     }
 }

--- a/src/integrations/aerodatabox/aeroClient.ts
+++ b/src/integrations/aerodatabox/aeroClient.ts
@@ -7,8 +7,21 @@ type CacheEntry = {
   status: AeroFlightStatus | null
 }
 
+type Provider = 'apimarket' | 'rapidapi'
+
+const PROVIDERS: Record<Provider, { baseUrl: string; headers: (key: string) => Record<string, string> }> = {
+  apimarket: {
+    baseUrl: 'https://prod.api.market/api/v1/aedbx/aerodatabox',
+    headers: (key) => ({ 'x-api-market-key': key, Accept: 'application/json' }),
+  },
+  rapidapi: {
+    baseUrl: 'https://aerodatabox.p.rapidapi.com',
+    headers: (key) => ({ 'x-rapidapi-key': key, 'x-rapidapi-host': 'aerodatabox.p.rapidapi.com', Accept: 'application/json' }),
+  },
+}
+
 export class AeroClient {
-  private readonly baseUrl = 'https://aerodatabox.p.rapidapi.com'
+  private readonly provider: (typeof PROVIDERS)[Provider]
   private readonly apiKey: string
 
   private readonly cache = new Map<string, CacheEntry>()
@@ -24,8 +37,10 @@ export class AeroClient {
   private processing = false
   private readonly queue: Array<() => void> = []
 
-  constructor(apiKey: string) {
+  constructor(apiKey: string, provider: Provider = 'apimarket') {
     this.apiKey = apiKey
+    this.provider = PROVIDERS[provider]
+    logger.debug(`[AERO] Using provider: ${provider}`)
   }
 
   private enqueue<T>(fn: () => Promise<T>): Promise<T> {
@@ -78,17 +93,13 @@ export class AeroClient {
   }
 
   async getFlightByNumber(flightNumber: string): Promise<AeroFlightContract | null> {
-    const url = `${this.baseUrl}/flights/number/${encodeURIComponent(flightNumber)}?withLocation=true`
+    const url = `${this.provider.baseUrl}/flights/number/${encodeURIComponent(flightNumber)}?withLocation=true`
 
     return this.enqueue(async () => {
       logger.debug(`[AERO] GET ${url}`)
 
       const res = await fetch(url, {
-        headers: {
-          'x-rapidapi-key': this.apiKey,
-          'x-rapidapi-host': 'aerodatabox.p.rapidapi.com',
-          Accept: 'application/json',
-        },
+        headers: this.provider.headers(this.apiKey),
       })
 
       if (res.status === 204) {

--- a/src/v1/controllers/flights/flightMarkupController.ts
+++ b/src/v1/controllers/flights/flightMarkupController.ts
@@ -8,7 +8,7 @@ import { buildFlightDisplayData } from '../../../integrations/aerodatabox/status
 import type { FlightDisplayData } from '../../../types/trmnl/flightTypes.js'
 import type { TrmnlMeta } from '../../../types/trmnl/types.js'
 
-const aeroClient = config.aerodatabox.apiKey ? new AeroClient(config.aerodatabox.apiKey) : null
+const aeroClient = config.aerodatabox.apiKey ? new AeroClient(config.aerodatabox.apiKey, config.aerodatabox.provider) : null
 const rotationIndex = new Map<string, number>()
 
 function nextRotationIndex(userUuid: string, count: number): number {


### PR DESCRIPTION
## Summary
- Switches AeroDataBox back to api.market as the default provider (`AERODATABOX_PROVIDER=apimarket`)
- Keeps RapidAPI available as a fallback via `AERODATABOX_PROVIDER=rapidapi`
- No API surface changes — same `AERODATABOX_API_KEY` env var is used for whichever provider is active

## Test plan
- [ ] Verify flight tracker renders correctly with `AERODATABOX_PROVIDER=apimarket`
- [ ] Verify `AERODATABOX_PROVIDER=rapidapi` still works for RapidAPI fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)