### PR TITLE
Fix graceful shutdown and tune AeroDataBox cache TTLs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ USER node
 WORKDIR /opt/api
 RUN npm ci --omit=dev
 COPY --chown=node:node --from=builder /opt/api/build ./build
-ENTRYPOINT [ "npm", "run", "start" ]
+ENTRYPOINT [ "node", "build/server.js" ]

--- a/src/integrations/aerodatabox/aeroClient.ts
+++ b/src/integrations/aerodatabox/aeroClient.ts
@@ -27,10 +27,10 @@ export class AeroClient {
   private readonly cache = new Map<string, CacheEntry>()
   private readonly inflight = new Map<string, Promise<AeroFlightContract | null>>()
 
-  // Status-aware cache TTLs
-  private readonly ACTIVE_TTL_MS = 5 * 60 * 1000 // 5 min — EnRoute, Departed, Approaching
-  private readonly PREFLIGHT_TTL_MS = 15 * 60 * 1000 // 15 min — Expected, CheckIn, Boarding, etc.
-  private readonly SETTLED_TTL_MS = 30 * 60 * 1000 // 30 min — Arrived, Canceled, Diverted
+  // 5 min under TRMNL's 1hr refresh so multi-device users share a single API call per cycle
+  private readonly ACTIVE_TTL_MS = 55 * 60 * 1000
+  // Settled flights won't move for ~2hrs (turnaround time), no need to poll frequently
+  private readonly SETTLED_TTL_MS = 2 * 60 * 60 * 1000
 
   private readonly MIN_INTERVAL_MS = 1100
   private lastCallAt = 0
@@ -72,21 +72,11 @@ export class AeroClient {
 
   private getTtl(status: AeroFlightStatus | null): number {
     switch (status) {
-      case 'EnRoute':
-      case 'Departed':
-      case 'Approaching':
-        return this.ACTIVE_TTL_MS
       case 'Arrived':
       case 'Canceled':
       case 'CanceledUncertain':
       case 'Diverted':
         return this.SETTLED_TTL_MS
-      case 'Expected':
-      case 'CheckIn':
-      case 'Boarding':
-      case 'GateClosed':
-      case 'Delayed':
-        return this.PREFLIGHT_TTL_MS
       default:
         return this.ACTIVE_TTL_MS
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -149,8 +149,16 @@ server.use((err: any, _req: any, res: any, _next: any) => {
   res.status(500).json({ error: 'server_error', error_description: 'Internal Server Error' })
 })
 
-server.listen(PORT, () => {
+const httpServer = server.listen(PORT, () => {
   logger.info('Using log level', config.api.logLevel)
   logger.info('Using API version:', config.api.activeVersion)
-logger.info('subspace API now listening on PORT:', config.api.port)
+  logger.info('subspace API now listening on PORT:', config.api.port)
+})
+
+process.on('SIGTERM', () => {
+  logger.info('SIGTERM received, shutting down gracefully')
+  httpServer.close(() => {
+    logger.info('Server closed')
+    process.exit(0)
+  })
 })


### PR DESCRIPTION
## Summary
- **Dockerfile**: ENTRYPOINT now runs `node` directly instead of `npm run start` — fixes `docker compose down` taking 20+ seconds by ensuring SIGTERM reaches the Node process
- **server.ts**: Added SIGTERM handler for graceful shutdown
- **aeroClient**: Simplified to two cache TTL tiers — 55min for active/preflight flights (aligned to 1hr TRMNL refresh cadence), 2hr for settled flights (Arrived/Canceled/Diverted) based on aircraft turnaround time

## Test plan
- [ ] `docker compose down` should stop in under 2 seconds
- [ ] Active/preflight flights expire from cache after 55min
- [ ] Arrived/Canceled/Diverted flights cache for 2hr

🤖 Generated with [Claude Code](https://claude.com/claude-code)