### PR TITLE
Minor refactor, log cleanup, moving logic around, flight cache fix, and DB cleanup ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ These are required if you are running TRMNL plugins (metro or flight tracker).
 | `TRMNL_DB_PATH` | No | Path to SQLite database file (default: `./trmnl.sqlite`) |
 | `TRMNL_IP_ALLOW_PRIVATE` | No | Set to `true` to bypass TRMNL worker IP allowlist check (useful for local dev) |
 
-## Discord activity settings
+## Discord activity settings (DEPRECATED ENDPOINT)
 | Env var | Purpose |
 |---------|---------|
 | `ACTIVITY_DISCORD_CLIENT_ID` | Discord OAuth client ID for the activity token exchange endpoint |
@@ -72,6 +72,8 @@ These are required if you are running TRMNL plugins (metro or flight tracker).
 # AI Disclosure
 Parts of this project were assisted with Claude Code by having it provide examples for implementation.
 Some parts of the codebase were refactored by Claude Code suggestion to improve efficiency.
+Unless noted, the code base was largely written by hand. Some parts of implementing the OAuth 2.0 spec were assisted by LLM.
+Some parts for the TRMNL Flight Tracker logic regarding calculations were assisted by LLM, as with information display, but not generated out of thin air.
 
 It is subspace's responsibility to examine the output of these LLMs for accuracy, implementation detail, and direction.
 

--- a/src/auth/trmnlAuth.ts
+++ b/src/auth/trmnlAuth.ts
@@ -1,3 +1,8 @@
+/**
+ * Custom middleware that performs authentication specifically against TRMNL workers and TRMNL endpoints
+ * Middleware exposes a way to parse the Bearer auth token sent from TRMNL and validate it
+ * against their .well-known JWKS
+ */
 import crypto from 'crypto'
 import { Request, Response, NextFunction, RequestHandler } from 'express'
 import { isKnownTokenHash, touchTrmnlToken } from '../utils/dbConnector.js'
@@ -20,7 +25,7 @@ const sha256 = (v: string) => crypto.createHash('sha256').update(v).digest('hex'
 // This is all middleware
 // Do not apply the same type of oauth here
 export const requireTrmnlAuth: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
-  logger.info('[AUTH] Checking TRMNL authentication')
+  logger.info('[AUTH] TRMNL Auth MW - checking for TRMNL credentials')
 
   const auth = req.headers.authorization
   if (!auth || typeof auth !== 'string' || !auth.toLowerCase().startsWith('bearer ')) {

--- a/src/integrations/aerodatabox/aeroClient.ts
+++ b/src/integrations/aerodatabox/aeroClient.ts
@@ -29,8 +29,8 @@ export class AeroClient {
 
   // 5 min under TRMNL's 1hr refresh so multi-device users share a single API call per cycle
   private readonly ACTIVE_TTL_MS = 55 * 60 * 1000
-  // Settled flights won't move for ~2hrs (turnaround time), no need to poll frequently
-  private readonly SETTLED_TTL_MS = 2 * 60 * 60 * 1000
+  // Settled flights keep the same flight number until next day's operation — 4hr cache is safe
+  private readonly SETTLED_TTL_MS = 4 * 60 * 60 * 1000
 
   private readonly MIN_INTERVAL_MS = 1100
   private lastCallAt = 0

--- a/src/integrations/aerodatabox/aeroClient.ts
+++ b/src/integrations/aerodatabox/aeroClient.ts
@@ -32,6 +32,7 @@ export class AeroClient {
   // Settled flights keep the same flight number until next day's operation — 4hr cache is safe
   private readonly SETTLED_TTL_MS = 4 * 60 * 60 * 1000
 
+  // API queue system
   private readonly MIN_INTERVAL_MS = 1100
   private lastCallAt = 0
   private processing = false
@@ -40,7 +41,7 @@ export class AeroClient {
   constructor(apiKey: string, provider: Provider = 'apimarket') {
     this.apiKey = apiKey
     this.provider = PROVIDERS[provider]
-    logger.debug(`[AERO] Using provider: ${provider}`)
+    logger.info(`[AERO] Using provider: ${provider}`)
   }
 
   private enqueue<T>(fn: () => Promise<T>): Promise<T> {
@@ -52,11 +53,12 @@ export class AeroClient {
           reject(e)
         }
       })
-      if (this.queue.length > 1) logger.debug(`[AERO] Queued request (depth: ${this.queue.length})`)
+      if (this.queue.length > 1) logger.info(`[AERO] Queued request (depth: ${this.queue.length})`)
       this.processQueue()
     })
   }
 
+  // flight API limits 1 req/s, at most 2 req/s
   private async processQueue(): Promise<void> {
     if (this.processing) return
     this.processing = true
@@ -110,6 +112,7 @@ export class AeroClient {
   }
 
   async getFlightByNumberCached(flightNumber: string): Promise<AeroFlightContract | null> {
+    logger.debug(`[AERO] retrieving flight information for ${flightNumber}`)
     const now = Date.now()
     const cached = this.cache.get(flightNumber)
     if (cached && now - cached.at < this.getTtl(cached.status)) {

--- a/src/integrations/wmata/wmataClient.ts
+++ b/src/integrations/wmata/wmataClient.ts
@@ -5,6 +5,11 @@ import { logger } from '../../utils/logger.js'
 export class WmataClient {
   private readonly apiKey: string
 
+  private cachedIncidents: MetroIncident[] | null = null
+  private cachedAtMs = 0
+  private inFlight: Promise<MetroIncident[]> | null = null
+  private readonly INCIDENTS_TTL_MS = 10 * 60 * 1000 // 10 minutes
+
   // todo - technically the trmnl (aero and wmata) are optional endpoints
   // don't hardcode a stop/exit
   constructor(opts: { apiKey: string }) {
@@ -12,7 +17,7 @@ export class WmataClient {
       logger.error('Unable to start subspace-api - missing WMATA API KEY')
       throw new Error('WMATA apiKey is required')
     }
-    
+
     this.apiKey = opts.apiKey
   }
 
@@ -43,5 +48,33 @@ export class WmataClient {
   async getIncidents(): Promise<MetroIncident[]> {
     const data = await this.getJson<MetroIncidentResponse>('https://api.wmata.com/Incidents.svc/json/Incidents')
     return data.Incidents
+  }
+
+  async getIncidentsCached(): Promise<MetroIncident[]> {
+    const now = Date.now()
+    if (this.cachedIncidents && now - this.cachedAtMs < this.INCIDENTS_TTL_MS) {
+      logger.debug('[WMATA] Cache hit for incidents')
+      return this.cachedIncidents
+    }
+
+    if (this.inFlight) return this.inFlight
+
+    logger.debug('[WMATA] Cache miss for incidents — fetching')
+    this.inFlight = (async () => {
+      const fresh = await this.getIncidents()
+      this.cachedIncidents = fresh
+      this.cachedAtMs = Date.now()
+      this.inFlight = null
+      return fresh
+    })().catch((err) => {
+      this.inFlight = null
+      if (this.cachedIncidents) {
+        logger.warn('[WMATA] Fetch failed, returning stale cache:', String(err))
+        return this.cachedIncidents
+      }
+      throw err
+    })
+
+    return this.inFlight
   }
 }

--- a/src/integrations/wmata/wmataClient.ts
+++ b/src/integrations/wmata/wmataClient.ts
@@ -5,6 +5,8 @@ import { logger } from '../../utils/logger.js'
 export class WmataClient {
   private readonly apiKey: string
 
+  // todo - technically the trmnl (aero and wmata) are optional endpoints
+  // don't hardcode a stop/exit
   constructor(opts: { apiKey: string }) {
     if (!opts.apiKey) {
       logger.error('Unable to start subspace-api - missing WMATA API KEY')
@@ -15,7 +17,6 @@ export class WmataClient {
   }
 
   private async getJson<T>(url: string): Promise<T> {
-    logger.debug('Performing WMATA integration API call')
     const res = await fetch(url, {
       method: 'GET',
       headers: { api_key: this.apiKey },

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,8 +2,8 @@ import path from 'path'
 import { fileURLToPath } from 'url'
 import { config } from './config.js' // validate and build config object
 import { logger } from './utils/logger.js'
-import express, { Request, NextFunction, Response, RequestHandler } from 'express'
-import { initTrmnlDB } from './utils/dbConnector.js'
+import express, { Request, Response } from 'express'
+import { initTrmnlDB, pruneStaleTokens } from './utils/dbConnector.js'
 import trmnlRouter from './v1/routers/trmnlRouter.js'
 import statusRouter from './v1/routers/statusRouter.js'
 import helmet from 'helmet'
@@ -42,11 +42,13 @@ logger.info('MCP server is ready')
 // TODO: switch to PG connection vs flat file
 logger.info('Initializing DB...')
 initTrmnlDB()
+pruneStaleTokens()
+const TOKEN_CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000 // once a day
+setInterval(pruneStaleTokens, TOKEN_CLEANUP_INTERVAL_MS).unref()
 
 // Express setup
 const server = express()
 const PORT = config.api.port
-const ACTIVE_VERSION = config.api.activeVersion
 
 // reverse proxy -- removing this will cause issues with secure cookies
 server.set('trust proxy', 1)
@@ -71,13 +73,6 @@ server.use(
 server.use('/health', rateLimiter, express.json(), statusRouter)
 server.use('/v1/trmnl', rateLimiter, trmnlRouter)
 
-// Wrapper around the handleRequest - I don't know if this is actually needed but it was suggested to me
-const safe = (fn: RequestHandler): RequestHandler => {
-  return (req: Request, res: Response, next: NextFunction) => {
-    Promise.resolve(fn(req, res, next)).catch(next)
-  }
-}
-
 server.all(
   '/mcp',
   logIncomingAuth,
@@ -85,7 +80,7 @@ server.all(
   userAuthMiddleware, // BFF pattern: verify X-User-Authorization for defense-in-depth
   rateLimiter,
   logAuthedIdentity,
-  safe(async (req: Request, res: Response) => {
+  async (req: Request, res: Response) => {
     const { server, transport } = createMcpHandler()
     await server.connect(transport)
 
@@ -101,7 +96,7 @@ server.all(
     } else {
       await transport.handleRequest(req, res, req.body)
     }
-  })
+  }
 )
 
 server.get('/mcp/health', async (_: Request, res: Response) => {
@@ -113,30 +108,6 @@ server.get('/mcp/health', async (_: Request, res: Response) => {
     return
   }
   res.status(200).json({ status: 'ok' })
-})
-
-// discord activity auth
-// Discord enpoint to return oauth2 token after user authentication
-server.post('/discord/token', logIncomingAuth, async (req, res) => {
-  // Exchange the code for an access_token
-  const response = await fetch(`https://discord.com/api/oauth2/token`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body: new URLSearchParams({
-      client_id: process.env.ACTIVITY_DISCORD_CLIENT_ID!,
-      client_secret: process.env.ACTIVITY_DISCORD_CLIENT_SECRET!,
-      grant_type: 'authorization_code',
-      code: req.body.code,
-    }),
-  })
-
-  // Retrieve the access_token from the response
-  const { access_token } = await response.json()
-
-  // Return the access_token to our client as { access_token: "..."}
-  res.send({ access_token })
 })
 
 // oauth

--- a/src/utils/authLogger.ts
+++ b/src/utils/authLogger.ts
@@ -8,14 +8,15 @@ export function logIncomingAuth(req: Request, _res: Response, next: NextFunction
   const auth = req.headers.authorization ?? ""
   const hasBearer = auth.toLowerCase().startsWith("bearer ")
 
-  logger.debug(`[AUTH] Connection from ${ip} - ${country} bearer=${hasBearer}`)
+  logger.info(`[AUTH] Connection from ${ip} - ${country} bearer=${hasBearer}`)
   next()
 }
 
 export function logAuthedIdentity(req: Request, _res: Response, next: NextFunction) {
   const authInfo = (req as any).authInfo ?? null
   if (authInfo) {
-    logger.debug(`[AUTH] Incoming Authenticated client=${authInfo.clientId} scopes=${(authInfo.scopes ?? []).join(' ')}`)
+    logger.info(`[AUTH] Incoming Authenticated client=${authInfo.clientId}`)
+    logger.debug(`[AUTH] Debug scopes: ${(authInfo.scopes ??[]).join(' ')}`)
   } else {
     logger.debug('[AUTH] No authInfo on request')
   }

--- a/src/utils/dbConnector.ts
+++ b/src/utils/dbConnector.ts
@@ -126,7 +126,7 @@ export function getUserUuidByTokenHash(tokenHash: string): string | null {
 // bind once: only set if currently null/empty
 export function bindUserUuidToToken(tokenHash: string, userUuid: string) {
   const db = getDb()
-  logger.info(`[ DB ] Binding ${userUuid} to ${tokenHash}`)
+  logger.info(`[ DB ] Binding user to ${tokenHash}`)
   db.prepare(
     `
     update trmnl_connections
@@ -135,6 +135,35 @@ export function bindUserUuidToToken(tokenHash: string, userUuid: string) {
       and (user_uuid is null or user_uuid = '')
   `
   ).run(userUuid, tokenHash)
+}
+
+export function pruneStaleTokens() {
+  const db = getDb()
+  const now = Date.now()
+  const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000
+  const oneYearMs = 365 * 24 * 60 * 60 * 1000
+
+  const { changes: revokedPruned } = db
+    .prepare(
+      `
+    delete from trmnl_connections
+    where revoked_at is not null
+      and revoked_at < ?
+  `
+    )
+    .run(now - ninetyDaysMs)
+
+  const { changes: stalePruned } = db
+    .prepare(
+      `
+    delete from trmnl_connections
+    where last_seen_at is null
+      and created_at < ?
+  `
+    )
+    .run(now - oneYearMs)
+
+  logger.info(`[ DB ] Token cleanup: removed ${revokedPruned} revoked, ${stalePruned} stale`)
 }
 
 export async function revokeByUserUuid(userUuid: string) {

--- a/src/utils/dbConnector.ts
+++ b/src/utils/dbConnector.ts
@@ -97,7 +97,7 @@ export async function isKnownTokenHash(tokenHash: string): Promise<boolean> {
 
 export async function touchTrmnlToken(tokenHash: string) {
   const db = getDb()
-  logger.debug('[ DB ] Refreshing user token')
+  logger.info('[ DB ] Refreshing user token')
   db.prepare(
     `
     update trmnl_connections
@@ -109,7 +109,7 @@ export async function touchTrmnlToken(tokenHash: string) {
 
 export function getUserUuidByTokenHash(tokenHash: string): string | null {
   const db = getDb()
-  logger.debug('[ DB ] Retrieving UUID for hash: ', tokenHash)
+  logger.info('[ DB ] Retrieving UUID for hash: ', tokenHash)
   const row = db
     .prepare(
       `
@@ -126,7 +126,7 @@ export function getUserUuidByTokenHash(tokenHash: string): string | null {
 // bind once: only set if currently null/empty
 export function bindUserUuidToToken(tokenHash: string, userUuid: string) {
   const db = getDb()
-  logger.debug(`[ DB ] Binding ${userUuid} to ${tokenHash}`)
+  logger.info(`[ DB ] Binding ${userUuid} to ${tokenHash}`)
   db.prepare(
     `
     update trmnl_connections

--- a/src/utils/trmnlMeta.ts
+++ b/src/utils/trmnlMeta.ts
@@ -1,0 +1,14 @@
+import type { TrmnlMeta } from '../types/trmnl/types.js'
+import { logger } from './logger.js'
+
+export function parseTrmnlMeta(raw: unknown): TrmnlMeta | null {
+  if (raw && typeof raw === 'object') return raw as TrmnlMeta
+  if (typeof raw === 'string' && raw.trim()) {
+    try {
+      return JSON.parse(raw) as TrmnlMeta
+    } catch {
+      logger.warn('[TRMNL] Failed to parse trmnl metadata JSON')
+    }
+  }
+  return null
+}

--- a/src/v1/controllers/flights/flightInstallSuccessController.ts
+++ b/src/v1/controllers/flights/flightInstallSuccessController.ts
@@ -27,6 +27,6 @@ export const flightInstallSuccessController: RequestHandler = async (req, res) =
     })
   }
 
-  logger.info('[FLIGHTS] install success for uuid', { userUuid })
+  logger.info('[AERO] install success for uuid', { userUuid })
   res.status(200).json({ ok: true })
 }

--- a/src/v1/controllers/flights/flightMarkupController.ts
+++ b/src/v1/controllers/flights/flightMarkupController.ts
@@ -6,7 +6,7 @@ import { AeroClient } from '../../../integrations/aerodatabox/aeroClient.js'
 import { renderMarkup } from '../../../integrations/aerodatabox/formatters.js'
 import { buildFlightDisplayData } from '../../../integrations/aerodatabox/statusMapper.js'
 import type { FlightDisplayData } from '../../../types/trmnl/flightTypes.js'
-import type { TrmnlMeta } from '../../../types/trmnl/types.js'
+import { parseTrmnlMeta } from '../../../utils/trmnlMeta.js'
 
 const aeroClient = config.aerodatabox.apiKey ? new AeroClient(config.aerodatabox.apiKey, config.aerodatabox.provider) : null
 const rotationIndex = new Map<string, number>()
@@ -41,17 +41,7 @@ export const flightMarkupController: RequestHandler = async (req, res) => {
     return
   }
 
-  // parse TRMNL meta (optional)
-  let meta: TrmnlMeta | null = null
-  if (trmnlRaw && typeof trmnlRaw === 'object') {
-    meta = trmnlRaw as TrmnlMeta
-  } else if (typeof trmnlRaw === 'string' && trmnlRaw.trim()) {
-    try {
-      meta = JSON.parse(trmnlRaw)
-    } catch {
-      logger.warn('[FLGHT] Failed to parse trmnl metadata JSON')
-    }
-  }
+  const meta = parseTrmnlMeta(trmnlRaw)
 
   const utcOffset = Number(meta?.user?.utc_offset ?? 0)
 

--- a/src/v1/controllers/metro/trmnlMarkupController.ts
+++ b/src/v1/controllers/metro/trmnlMarkupController.ts
@@ -4,15 +4,8 @@ import { config } from '../../../config.js'
 import { getSettingsByUuid } from '../../../utils/dbConnector.js'
 import { WmataClient } from '../../../integrations/wmata/wmataClient.js'
 import { MetroIncident } from '../../../types/wmata/types.js'
-import { TrmnlMeta, MetroMarkup, MarkupVariant } from '../../../types/trmnl/types.js'
-
-// Set up cache so we dont needlessly call to WMATA all the time
-// rough TTL of about 10 minutes, can change. Minimum at TRMNL is ~15 but can change based on device and dev
-let cachedIncidents: MetroIncident[] | null = null
-let cachedAtMs = 0
-let inFlight: Promise<MetroIncident[]> | null = null
-
-const WMATA_TTL_MS = 10 * 60 * 1000 // 10 minute cache
+import { MetroMarkup, MarkupVariant } from '../../../types/trmnl/types.js'
+import { parseTrmnlMeta } from '../../../utils/trmnlMeta.js'
 
 const client = config.wmata.apiKey ? new WmataClient({ apiKey: config.wmata.apiKey }) : null
 
@@ -41,17 +34,7 @@ export const trmnlMarkupController: RequestHandler = async (req, res) => {
     res.status(503).json({ error: 'Service Unavailable', message: 'WMATA monitoring not configured.'})
   }
 
-  // parse TRMNL meta (optional)
-  let meta: TrmnlMeta | null = null
-  if (trmnlRaw && typeof trmnlRaw === 'object') {
-    meta = trmnlRaw as TrmnlMeta
-  } else if (typeof trmnlRaw === 'string' && trmnlRaw.trim()) {
-    try {
-      meta = JSON.parse(trmnlRaw)
-    } catch {
-      logger.warn('[TRMNL] Failed to parse trmnl metadata JSON')
-    }
-  }
+  const meta = parseTrmnlMeta(trmnlRaw)
 
   const utcOffset = Number(meta?.user?.utc_offset ?? 0)
 
@@ -71,7 +54,7 @@ export const trmnlMarkupController: RequestHandler = async (req, res) => {
 
   let incidents: MetroIncident[] = []
   try {
-    incidents = await fetchWmataIncidentsCached()
+    incidents = await client!.getIncidentsCached()
     logger.debug('[TRMNL] WMATA incidents fetched', { count: incidents.length })
   } catch (e) {
     logger.warn('[WMATA] incidents fetch failed', String(e))
@@ -320,43 +303,6 @@ function countCommuteIssuesByLine(incidents: MetroIncident[]) {
   return { disruption, alert }
 }
 
-async function fetchWmataIncidents(): Promise<MetroIncident[]> {
-  logger.info('[TRMNL] Attempting WMATA API call')
-
-  try {
-    const response = await client!.getIncidents()
-    return Array.isArray(response) ? response : []
-  } catch (e) {
-    logger.warn(`[TRMNL] Failed to fetch WMATA incidents`)
-    throw new Error('WMATA incidents fetch failed')
-  }
-}
-
-async function fetchWmataIncidentsCached(): Promise<MetroIncident[]> {
-  const now = Date.now()
-  if (cachedIncidents && now - cachedAtMs < WMATA_TTL_MS) {
-    logger.debug('[TRMNL] Using cached info!')
-    return cachedIncidents
-  }
-
-  // de-dupe concurrent refreshes
-  if (inFlight) return inFlight
-
-  logger.debug('[TRMNL] Cache stale - using API call')
-  inFlight = (async () => {
-    const fresh = await fetchWmataIncidents()
-    cachedIncidents = fresh
-    cachedAtMs = Date.now()
-    inFlight = null
-    return fresh
-  })().catch((err) => {
-    logger.error('[TRMNL] Error updating in-memory cache for WMATA call')
-    inFlight = null
-    throw err
-  })
-
-  return inFlight
-}
 
 function statusFromCount(count: number, crass: boolean) {
   if (count === 0) return { status: "YOU'RE FINE. ", subtitle: 'No active delays' }


### PR DESCRIPTION
Primarily addresses some minor bug fixes, some log level cleanups and what is logged, and moved cache in the WMATA service to the client vs the controller itself.

To help save on API calls, settled flights are marked in the cache for 4 hours. This is usually the case for international flights where the flight number for the specific plane changes based on route. Rarely (I think?) does a flight number persist between multiple legs, unassociated with each other. Hoping this works. It made sense in my head though.

Also introduces DB cleanup operations. Right now, we leave uninstalled UUIDs in the DB, they're just marked as revoked. DB operation schedules every 24 hours a cleanup