### PR TITLE
TRMNL X sizing support for metro & flight plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 .DS_Store
 *.sqlite
 data
+.claude

--- a/src/auth/trmnlAuth.ts
+++ b/src/auth/trmnlAuth.ts
@@ -40,7 +40,7 @@ export const requireTrmnlAuth: RequestHandler = async (req: Request, res: Respon
   if (!(await isKnownTokenHash(tokenHash))) {
     logger.info('[AUTH] Unrecognized TRMNL token hash')
     logger.debug(tokenHash)
-    res.status(401).json({ error: 'Forbidden', message: 'Access Denied'})
+    res.status(401).json({ error: 'Unauthorized', message: 'Access Denied'})
     return
   }
 

--- a/src/integrations/aerodatabox/aeroClient.ts
+++ b/src/integrations/aerodatabox/aeroClient.ts
@@ -112,7 +112,7 @@ export class AeroClient {
   }
 
   async getFlightByNumberCached(flightNumber: string): Promise<AeroFlightContract | null> {
-    logger.debug(`[AERO] retrieving flight information for ${flightNumber}`)
+    logger.info(`[AERO] retrieving flight information for ${flightNumber}`)
     const now = Date.now()
     const cached = this.cache.get(flightNumber)
     if (cached && now - cached.at < this.getTtl(cached.status)) {

--- a/src/integrations/aerodatabox/formatters.ts
+++ b/src/integrations/aerodatabox/formatters.ts
@@ -101,40 +101,46 @@ export function renderMarkup(
   const lastUpdated = flights.length > 0 ? flights[0].lastUpdated : '--'
   const flightCards = flights.map((f) => renderFlightCard(f, variant, baseUrl)).join('')
 
+  // TRMNL X helper
+  const s = (px: number) => `calc(${px}px * var(--s, 1))`
+
   return `
 <style>
-  .flight-card { margin: ${variant === 'full' ? '0' : variant === 'half_vertical' ? '12px 0 0' : variant === 'half_horizontal' ? '8px 0' : '6px 8px'}; padding: ${variant === 'full' ? '12px 24px' : '0'}; font-family: 'IBM Plex Sans', 'SF Pro Text', 'Segoe UI', sans-serif; display: flex; flex-direction: column; flex: 1; }
-  .flight-details { margin-top: ${variant === 'full' ? '60px' : variant === 'half_vertical' ? '0' : '0'}; }
-  .flight-top { display: flex; align-items: center; gap: ${variant === 'quadrant' ? '12px' : '20px'}; width: 100%; }
-  .view--half_horizontal .flight-top { display: grid; grid-template-columns: auto 1fr auto; grid-template-rows: auto auto; align-items: center; column-gap: 16px; row-gap: 2px; }
+  .flight-card { --s: 1; }
+  .screen--lg .flight-card { --s: 1.3; }
+
+  .flight-card { margin: ${variant === 'full' ? '0' : variant === 'half_vertical' ? `${s(12)} 0 0` : variant === 'half_horizontal' ? `${s(8)} 0` : `${s(6)} ${s(8)}`}; padding: ${variant === 'full' ? `${s(12)} ${s(24)}` : '0'}; font-family: 'IBM Plex Sans', 'SF Pro Text', 'Segoe UI', sans-serif; display: flex; flex-direction: column; flex: 1; }
+  .flight-details { margin-top: ${variant === 'full' ? s(60) : '0'}; }
+  .flight-top { display: flex; align-items: center; gap: ${variant === 'quadrant' ? s(12) : s(20)}; width: 100%; }
+  .view--half_horizontal .flight-top { display: grid; grid-template-columns: auto 1fr auto; grid-template-rows: auto auto; align-items: center; column-gap: ${s(16)}; row-gap: ${s(2)}; }
   .view--half_horizontal .airline-logo { grid-column: 1; grid-row: 1; align-self: center; }
   .view--half_horizontal .flight-meta { grid-column: 3; grid-row: 1; }
-  .flight-meta { display: flex; flex-direction: column; gap: ${variant === 'quadrant' ? '3px' : '5px'}; align-items: flex-end; text-align: right; margin-left: auto; }
-  .airline-name { font-size: ${variant === 'quadrant' ? '18px' : variant === 'full' ? '30px' : '24px'}; font-weight: 700; letter-spacing: 0.2px; }
-  .flight-number { font-size: ${variant === 'quadrant' ? '26px' : variant === 'full' ? '44px' : '34px'}; font-weight: 800; }
-  .flight-aircraft { font-size: ${variant === 'quadrant' ? '14px' : variant === 'full' ? '20px' : '17px'}; font-weight: 500; color: #444; }
-  .flight-status { font-size: ${variant === 'quadrant' ? '16px' : variant === 'full' ? '24px' : '20px'}; font-weight: 600; }
-  .flight-route { display: flex; align-items: center; gap: 12px; width: 100%; font-size: ${variant === 'quadrant' ? '20px' : '28px'}; font-weight: 700; margin: ${variant === 'quadrant' ? '8px 0 5px' : '14px 0 8px'}; }
+  .flight-meta { display: flex; flex-direction: column; gap: ${variant === 'quadrant' ? s(3) : s(5)}; align-items: flex-end; text-align: right; margin-left: auto; }
+  .airline-name { font-size: ${variant === 'quadrant' ? s(18) : variant === 'full' ? s(30) : s(24)}; font-weight: 700; letter-spacing: 0.2px; }
+  .flight-number { font-size: ${variant === 'quadrant' ? s(26) : variant === 'full' ? s(44) : s(34)}; font-weight: 800; }
+  .flight-aircraft { font-size: ${variant === 'quadrant' ? s(14) : variant === 'full' ? s(20) : s(17)}; font-weight: 500; color: #444; }
+  .flight-status { font-size: ${variant === 'quadrant' ? s(16) : variant === 'full' ? s(24) : s(20)}; font-weight: 600; }
+  .flight-route { display: flex; align-items: center; gap: ${s(12)}; width: 100%; font-size: ${variant === 'quadrant' ? s(20) : s(28)}; font-weight: 700; margin: ${variant === 'quadrant' ? `${s(8)} 0 ${s(5)}` : `${s(14)} 0 ${s(8)}`}; }
   .view--half_vertical { display: flex; flex-direction: column; flex: 1; align-items: stretch; width: 100%; }
-  .view--half_vertical .flight-top { margin-bottom: 64px; }
-  .view--half_vertical .flight-details { margin-top: auto; display: flex; flex-direction: column; gap: 16px; }
-  .view--half_vertical .flight-stats { margin-top: 64px; font-size: 14px; gap: 10px; justify-content: space-between; }
+  .view--half_vertical .flight-top { margin-bottom: ${s(64)}; }
+  .view--half_vertical .flight-details { margin-top: auto; display: flex; flex-direction: column; gap: ${s(16)}; }
+  .view--half_vertical .flight-stats { margin-top: ${s(64)}; font-size: ${s(14)}; gap: ${s(10)}; justify-content: space-between; }
   .view--half_vertical .flight-route { width:100%; margin: 0; }
   .view--half_vertical .stat-item { display: flex; flex-direction: column; align-items: center; }
-  .view--half_vertical .stat-value { font-size: 16px; font-weight: 700; }
-  .view--half_horizontal .flight-top .flight-route { grid-column: 1 / -1; grid-row: 2; margin: 6px 0 0; font-size: 22px; }
-  .view--half_horizontal .flight-top .flight-stats { grid-column: 2; grid-row: 1; flex-direction: column; align-items: flex-start; justify-self: center; gap: 2px; font-size: 16px; margin-top: 0; }
+  .view--half_vertical .stat-value { font-size: ${s(16)}; font-weight: 700; }
+  .view--half_horizontal .flight-top .flight-route { grid-column: 1 / -1; grid-row: 2; margin: ${s(6)} 0 0; font-size: ${s(22)}; }
+  .view--half_horizontal .flight-top .flight-stats { grid-column: 2; grid-row: 1; flex-direction: column; align-items: flex-start; justify-self: center; gap: ${s(2)}; font-size: ${s(16)}; margin-top: 0; }
   .view--half_horizontal .flight-stat-aircraft { font-weight: 600; }
-  .view--half_horizontal .airline-name { font-size: 20px; }
-  .view--half_horizontal .flight-number { font-size: 30px; }
+  .view--half_horizontal .airline-name { font-size: ${s(20)}; }
+  .view--half_horizontal .flight-number { font-size: ${s(30)}; }
   .view--half_horizontal .flight-aircraft { display: none; }
-  .view--half_horizontal .flight-status { font-size: 18px; }
-  .view--half_horizontal .route-plane { font-size: 28px; }
-  .route-line { flex: 1; height: 2px; background: black; position: relative; }
-  .route-plane { font-size: ${variant === 'quadrant' ? '28px' : variant === 'full' ? '48px' : '36px'}; line-height: 1; }
-  .flight-stats { display: flex; ${variant === 'full' ? 'justify-content: space-between;' : `gap: ${variant === 'quadrant' ? '14px' : '26px'};`} font-size: ${variant === 'full' ? '24px' : variant === 'quadrant' ? '15px' : '20px'}; margin-top: ${variant === 'quadrant' ? '3px' : '7px'}; }
+  .view--half_horizontal .flight-status { font-size: ${s(18)}; }
+  .view--half_horizontal .route-plane { font-size: ${s(28)}; }
+  .route-line { flex: 1; height: ${s(2)}; background: black; position: relative; }
+  .route-plane { font-size: ${variant === 'quadrant' ? s(28) : variant === 'full' ? s(48) : s(36)}; line-height: 1; }
+  .flight-stats { display: flex; ${variant === 'full' ? 'justify-content: space-between;' : `gap: ${variant === 'quadrant' ? s(14) : s(26)};`} font-size: ${variant === 'full' ? s(24) : variant === 'quadrant' ? s(15) : s(20)}; margin-top: ${variant === 'quadrant' ? s(3) : s(7)}; }
   .stat-label { font-weight: 700; }
-  .airline-logo { width: 100%; max-width: ${logoWidth}; max-height: ${logoHeight}; object-fit: contain; }
+  .airline-logo { width: 100%; max-width: calc(${logoWidth} * var(--s, 1)); max-height: calc(${logoHeight} * var(--s, 1)); object-fit: contain; }
 </style>
 <div class="view view--${variant}">
   <div class="layout">
@@ -226,12 +232,17 @@ function renderFlightCard(f: FlightDisplayData, variant: MarkupVariant, baseUrl:
 function renderEmptyMarkup(variant: MarkupVariant): string {
   const textSize = variant === 'quadrant' ? '20px' : '28px'
   return `
+<style>
+  /* TRMNL X scale-up: see renderMarkup for the rationale. */
+  .flight-empty { --s: 1; font-size: calc(${textSize} * var(--s, 1)); font-weight: 600; padding: calc(40px * var(--s, 1)) 0; }
+  .screen--lg .flight-empty { --s: 1.3; }
+</style>
 <div class="view view--${variant}">
   <div class="layout">
     <div class="columns">
       <div class="column">
         <div class="markdown" style="text-align:center;">
-          <div style="font-size: ${textSize}; font-weight: 600; padding: 40px 0;">
+          <div class="flight-empty">
             Configure flights in settings
           </div>
         </div>

--- a/src/integrations/wmata/wmataClient.ts
+++ b/src/integrations/wmata/wmataClient.ts
@@ -2,13 +2,21 @@
 import type { RailPrediction, RailPredictionResponse, MetroIncident, MetroIncidentResponse } from '../../types/wmata/types.js'
 import { logger } from '../../utils/logger.js'
 
+type CacheEntry<T> = { at: number; data: T }
+
 export class WmataClient {
   private readonly apiKey: string
 
+  // Incidents cache
   private cachedIncidents: MetroIncident[] | null = null
   private cachedAtMs = 0
   private inFlight: Promise<MetroIncident[]> | null = null
   private readonly INCIDENTS_TTL_MS = 10 * 60 * 1000 // 10 minutes
+
+  // Station predictions cache
+  private readonly stationCache = new Map<string, CacheEntry<RailPrediction[]>>()
+  private readonly stationInFlight = new Map<string, Promise<RailPrediction[]>>()
+  private readonly STATION_TTL_MS = 60 * 1000 // 1 minute
 
   // todo - technically the trmnl (aero and wmata) are optional endpoints
   // don't hardcode a stop/exit
@@ -26,7 +34,7 @@ export class WmataClient {
       method: 'GET',
       headers: { api_key: this.apiKey },
     })
-
+    logger.debug(`[WMATA] Performing call for ${url}`)
     if (!res.ok) {
       logger.warn(`Unable to retrieve WMATA response. Got ${res.status} - ${res.statusText}`)
       throw new Error(`WMATA API Error: ${res.status} ${res.statusText}`)
@@ -39,13 +47,75 @@ export class WmataClient {
     if (stationCodes.length === 0) return []
     // WMATA expects comma-separated station codes in the path
     const joined = stationCodes.map(encodeURIComponent).join(',')
+    logger.info(`[WMATA] Retrieving predictions for ${joined}`)
     const data = await this.getJson<RailPredictionResponse>(
       `https://api.wmata.com/StationPrediction.svc/json/GetPrediction/${joined}`
     )
     return data.Trains
   }
 
+  // Basically, we create a cache per station (LocationCode) with a TTL of 1 minute based on station
+  // Here we can leverage the ability to cache based on other user requests
+  async getRailPredictionsCached(codes: string[]): Promise<{ trains: RailPrediction[]; cached: boolean }> {
+    // 'All' bypasses per-station cache — too broad to cache meaningfully
+    if (codes.length === 1 && codes[0] === 'All') {
+      const trains = await this.getRailPredictions(['All'])
+      return { trains, cached: false }
+    }
+
+    const merged: RailPrediction[] = []
+    const missing: string[] = []
+
+    for (const code of codes) {
+      const hit = this.stationCache.get(code)
+      if (hit && Date.now() - hit.at < this.STATION_TTL_MS) {
+        merged.push(...hit.data)
+      } else {
+        missing.push(code)
+      }
+    }
+
+    if (missing.length) {
+      const trulyMissing = missing.filter((code) => !this.stationInFlight.has(code))
+
+      if (trulyMissing.length) {
+        const batchPromise = this.fetchMissingStations(trulyMissing)
+        for (const code of trulyMissing) {
+          const p = batchPromise.then((getSlice) => getSlice(code)).finally(() => this.stationInFlight.delete(code))
+          this.stationInFlight.set(code, p)
+        }
+      }
+
+      const fetchedSlices = await Promise.all(missing.map((code) => this.stationInFlight.get(code)!))
+      for (const slice of fetchedSlices) merged.push(...slice)
+    }
+
+    return { trains: merged, cached: missing.length === 0 }
+  }
+
+  // Hydrate cache with any missing stations
+  private async fetchMissingStations(missing: string[]): Promise<(code: string) => RailPrediction[]> {
+    logger.debug(`[WMATA] Fetching missing stations: [${missing.join(',')}]`)
+    const trains = await this.getRailPredictions(missing)
+    const grouped = new Map<string, RailPrediction[]>()
+    for (const t of trains ?? []) {
+      const code = (t.LocationCode ?? '').toUpperCase()
+      if (!code) continue
+      const arr = grouped.get(code)
+      if (arr) arr.push(t)
+      else grouped.set(code, [t])
+    }
+    const now = Date.now()
+    for (const code of missing) {
+      this.stationCache.set(code, { at: now, data: grouped.get(code) ?? [] })
+    }
+    return (code: string) => this.stationCache.get(code)?.data ?? []
+  }
+
+  ///////////////////////
+
   async getIncidents(): Promise<MetroIncident[]> {
+    logger.info('[WMATA] Retrieving WMATA incidents')
     const data = await this.getJson<MetroIncidentResponse>('https://api.wmata.com/Incidents.svc/json/Incidents')
     return data.Incidents
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -128,6 +128,7 @@ const httpServer = server.listen(PORT, () => {
 
 process.on('SIGTERM', () => {
   logger.info('SIGTERM received, shutting down gracefully')
+  httpServer.closeAllConnections()
   httpServer.close(() => {
     logger.info('Server closed')
     process.exit(0)

--- a/src/server.ts
+++ b/src/server.ts
@@ -63,7 +63,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 server.use(
   '/public',
   (req, _res, next) => {
-    logger.info(`[STATIC] ${req.method} ${req.path}`)
+    logger.info(`${req.method} ${req.path}`)
     next()
   },
   helmet({ crossOriginResourcePolicy: { policy: 'cross-origin' } }),

--- a/src/utils/rateLimiter.ts
+++ b/src/utils/rateLimiter.ts
@@ -39,7 +39,7 @@ export const rateLimiter: RateLimitRequestHandler = rateLimit({
     const ip = getClientIp(req)
     const key = getAuthKey(req)
     if (isTrmnlWorkerIp(ip)) {
-      logger.info(`Rate limit check for TRMNL IP: ${ip}`)
+      logger.debug(`Rate limit check for TRMNL IP: ${ip}`)
       return 60
     }
     logger.info(`Rate limit check for ${key ? 'authenticated' : 'anon'} - ${ip}`)

--- a/src/v1/controllers/flights/flightMarkupController.ts
+++ b/src/v1/controllers/flights/flightMarkupController.ts
@@ -37,7 +37,7 @@ export const flightMarkupController: RequestHandler = async (req, res) => {
 
   if (!aeroClient) {
     logger.warn('[FLGHT] AeroDataBox API key not configured')
-    res.status(503).json({ error: 'Service Unavailable', message: 'Flight tracking not configured' })
+    res.status(503).json({ error: 'Service Unavailable', message: 'Service Unavailable :(' })
     return
   }
 

--- a/src/v1/controllers/metro/trmnlMarkupController.ts
+++ b/src/v1/controllers/metro/trmnlMarkupController.ts
@@ -144,11 +144,14 @@ function renderMarkup(m: MetroMarkup, variant: MarkupVariant): string {
 
   return `
 <style>
-  .big-status { font-size: ${bigText}; font-weight: 700; letter-spacing: 2px; }
+  .content-element { --s: 1; }
+  .screen--lg .content-element { --s: 1.3; }
+
+  .big-status { font-size: calc(${bigText} * var(--s, 1)); font-weight: 700; letter-spacing: 2px; }
 
   .line-indicators {
       display: flex;
-      gap: 12px;
+      gap: calc(12px * var(--s, 1));
   }
 
   /* line colors */
@@ -161,14 +164,14 @@ function renderMarkup(m: MetroMarkup, variant: MarkupVariant): string {
 
   .line-dot {
       position: relative;
-      width: 64px;
-      height: 64px;
+      width: calc(64px * var(--s, 1));
+      height: calc(64px * var(--s, 1));
       border-radius: 999px;
       display: flex;
       align-items: center;
       justify-content: center;
       font-weight: 700;
-      font-size: 28px;
+      font-size: calc(28px * var(--s, 1));
       color: white;
   }
 
@@ -177,12 +180,12 @@ function renderMarkup(m: MetroMarkup, variant: MarkupVariant): string {
       position: absolute;
       bottom: -4px;
       right: -4px;
-      width: 24px;
-      height: 24px;
+      width: calc(24px * var(--s, 1));
+      height: calc(24px * var(--s, 1));
       border-radius: 999px;
       background: white;
       color: black;
-      font-size: 18px;
+      font-size: calc(18px * var(--s, 1));
       font-weight: 900;
       display: flex;
       align-items: center;
@@ -208,7 +211,7 @@ function renderMarkup(m: MetroMarkup, variant: MarkupVariant): string {
           ${variant !== 'quadrant' ? `<span class="title">${escapeHtml(m.instanceName)} • ${escapeHtml(m.displayLine)}</span>` : ``}
           <div class="content-element" style="display: flex;flex-direction: column;align-items: center;justify-content: center;${variant === 'full' || variant === 'half_vertical' ? `gap: 12px;` : ``}">
           <div class="big-status">${escapeHtml(m.status)}</div>
-          ${showSubtitle ? `<div class="label mt-2" style="font-size: ${subtitleSize};">${escapeHtml(m.subtitleFinal)}</div>` : ``}
+          ${showSubtitle ? `<div class="label mt-2" style="font-size: calc(${subtitleSize} * var(--s, 1));">${escapeHtml(m.subtitleFinal)}</div>` : ``}
           ${m.dots ? `<div class="line-indicators" style="margin-top:24px;margin-bottom:20px;">${m.dots}</div>` : ``}
           </div>
         </div>

--- a/src/v1/controllers/metro/trmnlStationPrediction.ts
+++ b/src/v1/controllers/metro/trmnlStationPrediction.ts
@@ -1,25 +1,9 @@
-/**
- * This handler lets us cache rail predictions (with a TTL of 1 minute) based on station
- * We can also leverage the ability to cache stations from other people's requests to serve other requests
- * Basically a cache per LocationCode in case a user passes in more than one station code
- * This handler may chance to only permit one station code vs more than one
- */
 import { RequestHandler } from 'express'
 import { logger } from '../../../utils/logger.js'
 import { config } from '../../../config.js'
 import { WmataClient } from '../../../integrations/wmata/wmataClient.js'
-import { RailPrediction } from '../../../types/wmata/types.js'
 
 const client = new WmataClient({ apiKey: config.wmata.apiKey })
-
-const TTL_MS = 60 * 1000
-
-type CacheEntry<T> = { at: number; data: T }
-
-const stationCache = new Map<string, CacheEntry<RailPrediction[]>>() // B03 -> trains
-const stationInFlight = new Map<string, Promise<RailPrediction[]>>() // B03 -> promise
-
-const isFresh = (hit?: CacheEntry<any>) => !!hit && Date.now() - hit.at < TTL_MS
 
 function normalizeStationCodes(codes: string[]) {
   const normalized = codes.map((c) => c.trim()).filter(Boolean)
@@ -27,98 +11,21 @@ function normalizeStationCodes(codes: string[]) {
   return [...new Set(normalized.map((c) => c.toUpperCase()))].sort()
 }
 
-// this lets us cache other station codes if other requests happen to include one
-function groupByLocationCode(trains: RailPrediction[]) {
-  const m = new Map<string, RailPrediction[]>()
-  for (const t of trains ?? []) {
-    const code = (t.LocationCode ?? '').toUpperCase()
-    if (!code) continue
-    const arr = m.get(code)
-    if (arr) arr.push(t)
-    else m.set(code, [t])
-  }
-  return m
-}
-
-async function fetchMissingStations(missing: string[]) {
-  logger.debug(`[TRMNL] Performing WMATA integration API call for missing=[${missing.join(',')}]`)
-  const trains: RailPrediction[] = await client.getRailPredictions(missing)
-  const grouped = groupByLocationCode(trains)
-  const now = Date.now()
-
-  for (const code of missing) {
-    stationCache.set(code, { at: now, data: grouped.get(code) ?? [] })
-  }
-
-  // return trains per station from cache (so each stationInFlight resolves to its own slice)
-  return (code: string) => stationCache.get(code)?.data ?? []
-}
-
 export const trmnlStationPrediction: RequestHandler = async (req, res) => {
   try {
-    logger.debug('[TRMNL] Received rail prediction request')
+    logger.debug('[WMATA] Received rail prediction request')
 
     const raw = req.query.stations
     const stationsStr = Array.isArray(raw) ? raw.join(',') : (raw as string | undefined)
-    if (stationsStr?.length === 0) {
-      res.status(400).json({ error: 'Bad Request', message: 'Cannot pass in no station codes'})
+    if (!stationsStr?.length) {
+      res.status(400).json({ error: 'Bad Request', message: 'Cannot pass in no station codes' })
       return
     }
 
-    const requested = stationsStr?.split(',') ?? []
-    const codes = normalizeStationCodes(requested)
-
-    if (codes[0] === 'All') {
-      const trains: RailPrediction[] = await client.getRailPredictions(['All'])
-      res.status(200).json({ Trains: trains, cached: false })
-      return
-    }
-
-    // serve what we can from cache
-    const merged: RailPrediction[] = []
-    const missing: string[] = []
-
-    for (const code of codes) {
-      const hit = stationCache.get(code)
-      if (isFresh(hit)) {
-        merged.push(...hit!.data)
-      } else {
-        missing.push(code)
-      }
-    }
-
-    //kick off (or join) in-flight per missing station
-    if (missing.length) {
-      // any stations already fetching?
-      const trulyMissing: string[] = []
-      for (const code of missing) {
-        if (!stationInFlight.has(code)) trulyMissing.push(code)
-      }
-
-      // do ONE WMATA call for any missing stations with expired TTL
-      if (trulyMissing.length) {
-        const batchPromise = (async () => {
-          const getSlice = await fetchMissingStations(trulyMissing)
-          return getSlice
-        })()
-
-        for (const code of trulyMissing) {
-          const p = batchPromise.then((getSlice) => getSlice(code)).finally(() => stationInFlight.delete(code))
-          stationInFlight.set(code, p)
-        }
-      }
-
-      // wait for all missing stations (some may have been in-flight already)
-      const fetchedSlices = await Promise.all(missing.map((code) => stationInFlight.get(code)!))
-      for (const slice of fetchedSlices) merged.push(...slice)
-    }
-
-    // cached=true only if we didn’t need to fetch anything
-    const cached = missing.length === 0
-    res.status(200).json({ Trains: merged, cached })
-    return
-  } catch (e) {
+    const codes = normalizeStationCodes(stationsStr.split(','))
+    const { trains, cached } = await client.getRailPredictionsCached(codes)
+    res.status(200).json({ Trains: trains, cached })
+  } catch {
     res.status(502).json({ error: 'WMATA upstream error' })
-    return
   }
 }


### PR DESCRIPTION
## Summary
Makes the TRMNL plugins render well on the larger **TRMNL X** display (`screen--v2`, 1040×780, 4-bit).

TRMNL X uses the same `--ui-scale` (1) as the original TRMNL, so plugin content does not auto-enlarge — it must opt into the bigger screen. Every px size now rides a `--s` multiplier that stays `1` on the OG (`screen--md`) and bumps to `1.3` on the framework's real large-screen breakpoint (`screen--lg`, which the platform sets on TRMNL X). The original TRMNL render is byte-identical (`var(--s, 1)` falls back to 1).

- **Metro** (`trmnlMarkupController.ts`): scaled `.big-status`, subtitle, line dots, alert overlays.
- **Flights** (`aerodatabox/formatters.ts`): `s(px)` helper scales the full `<style>` block + empty state.

## Also included
3 earlier `dev` commits not yet on `v1`: wmata caching location, minor updates, logging tweak.

## Verification
- `npm run build` passes.
- No device-side rendering change on the original TRMNL (scale knob defaults to 1).
- Visual check on TRMNL X best done via the framework device preview (`screen--v2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)