### PR TITLE
Fix serif font fallback on metro plugin

### DIFF
--- a/src/v1/controllers/metro/trmnlMarkupController.ts
+++ b/src/v1/controllers/metro/trmnlMarkupController.ts
@@ -144,7 +144,10 @@ function renderMarkup(m: MetroMarkup, variant: MarkupVariant): string {
 
   return `
 <style>
-  .content-element { --s: 1; }
+  /* Custom classes don't inherit the framework's Inter font (only framework classes do), so they'd fall
+     back to the engine's default serif. Set it on the content root so the status text, line dots, and
+     alert badges all match the title bar / instance name. */
+  .content-element { --s: 1; font-family: "Inter Variable", Inter, "Helvetica Neue", Arial, sans-serif; }
   .screen--lg .content-element { --s: 1.3; }
 
   .big-status { font-size: calc(${bigText} * var(--s, 1)); font-weight: 700; letter-spacing: 2px; }


### PR DESCRIPTION
## Summary
Fixes the metro plugin's status text rendering in a serif font.

`.big-status`, the line dots, and the alert badges are custom classes, so they don't inherit the framework's Inter font (only framework classes do) and fell back to the render engine's default serif. This sets the Inter stack on `.content-element` so they match the title bar and instance name.

Pre-existing issue (not from the TRMNL X sizing work), surfaced in a half-horizontal split.

## Verification
- `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)