### PR TITLE
Flight tracker full-variant arc redesign + progress on all variants

### DIFF
--- a/flight-preview.html
+++ b/flight-preview.html
@@ -1,0 +1,845 @@
+<!doctype html><html><head><meta charset="utf-8"><title>Flight Tracker — markup preview</title>
+<style>
+  :root{ font-family: -apple-system, system-ui, sans-serif; }
+  body{ margin:24px; background:#e9e9ee; color:#111; }
+  h1{ font-size:18px; } h2{ font-size:15px; margin:28px 0 10px; }
+  .grid{ display:flex; flex-wrap:wrap; gap:22px; align-items:flex-start; }
+  figure{ margin:0; }
+  figcaption{ font-size:12px; color:#555; margin-bottom:6px; font-family:ui-monospace,monospace; }
+  /* --- minimal TRMNL framework harness (approximates device chrome) --- */
+  .screen{ --s:1; box-sizing:border-box; background:#fff; border:1px solid #000; overflow:hidden;
+           display:flex; flex-direction:column; position:relative; }
+  .screen .view{ flex:1; display:flex; flex-direction:column; min-height:0; }
+  .screen .layout,.screen .columns,.screen .column,.screen .markdown{ display:flex; flex-direction:column; flex:1; min-height:0; }
+  .screen .title_bar{ display:flex; justify-content:space-between; align-items:center;
+           padding:7px 14px; border-top:1px solid #d8d8d8; font-size:13px; background:#f4f4f4; }
+  .screen .title_bar .instance{ color:#777; }
+</style></head>
+<body>
+  <h1>Flight Tracker — markup preview <span style="font-weight:400;color:#666">(UA 1074 · 62% en route)</span></h1>
+  <p style="font-size:12px;color:#666;max-width:760px">Approximated TRMNL chrome. The "UNITED AIRLINES" box is a placeholder stand-in for the real dithered airline banner. TRMNL X tiles carry <code>screen--lg</code> (--s scales to 1.3).</p>
+  <section>
+    <h2>Regular TRMNL — 800×480</h2>
+    <div class="grid">
+    <figure>
+      <figcaption>full — 800×480</figcaption>
+      <div class="screen " style="width:800px;height:480px">
+        <style>
+  .flight-card { --s: 1; }
+  .screen--lg .flight-card { --s: 1.3; }
+
+  /* full variant: hero arc + stat tiles. Stretch the framework chain so the
+     card can distribute its blocks top-to-bottom and fill the taller X screen. */
+  .view--full, .view--full .layout, .view--full .columns, .view--full .column, .view--full .markdown { display: flex; flex-direction: column; flex: 1; width: 100%; }
+  .view--full .flight-card { justify-content: space-between; padding: calc(20px * var(--s, 1)) calc(40px * var(--s, 1)); }
+  .view--full .flight-top { align-items: center; }
+  .flight-arc-wrap { display: flex; align-items: center; gap: calc(10px * var(--s, 1)); width: 100%; }
+  .arc-end { display: flex; flex-direction: column; align-items: center; min-width: calc(96px * var(--s, 1)); }
+  .arc-code { font-size: calc(40px * var(--s, 1)); font-weight: 800; line-height: 1; }
+  .arc-time { font-size: calc(18px * var(--s, 1)); font-weight: 600; color: #333; margin-top: calc(4px * var(--s, 1)); }
+  .arc-svg { flex: 1 1 0; min-width: 0; height: auto; display: block; overflow: visible; }
+  .stat-tiles { display: flex; gap: calc(12px * var(--s, 1)); width: 100%; }
+  .stat-tile { flex: 1; border: calc(2px * var(--s, 1)) solid black; border-radius: calc(10px * var(--s, 1)); padding: calc(10px * var(--s, 1)) calc(6px * var(--s, 1)); display: flex; flex-direction: column; align-items: center; gap: calc(3px * var(--s, 1)); }
+  .stat-tile-label { font-size: calc(15px * var(--s, 1)); font-weight: 700; letter-spacing: 1.5px; }
+  .stat-tile-value { font-size: calc(26px * var(--s, 1)); font-weight: 800; }
+
+  .flight-card { margin: 0; padding: calc(12px * var(--s, 1)) calc(24px * var(--s, 1)); font-family: 'IBM Plex Sans', 'SF Pro Text', 'Segoe UI', sans-serif; display: flex; flex-direction: column; flex: 1; }
+  .flight-details { margin-top: calc(60px * var(--s, 1)); }
+  .flight-top { display: flex; align-items: center; gap: calc(20px * var(--s, 1)); width: 100%; }
+  .view--half_horizontal .flight-top { display: grid; grid-template-columns: auto 1fr auto; grid-template-rows: auto auto; align-items: center; column-gap: calc(16px * var(--s, 1)); row-gap: calc(2px * var(--s, 1)); }
+  .view--half_horizontal .airline-logo { grid-column: 1; grid-row: 1; align-self: center; }
+  .view--half_horizontal .flight-meta { grid-column: 3; grid-row: 1; }
+  .flight-meta { display: flex; flex-direction: column; gap: calc(5px * var(--s, 1)); align-items: flex-end; text-align: right; margin-left: auto; }
+  .airline-name { font-size: calc(30px * var(--s, 1)); font-weight: 700; letter-spacing: 0.2px; }
+  .flight-number { font-size: calc(44px * var(--s, 1)); font-weight: 800; }
+  .flight-aircraft { font-size: calc(20px * var(--s, 1)); font-weight: 500; color: #444; }
+  .flight-status { font-size: calc(24px * var(--s, 1)); font-weight: 600; }
+  .flight-route { display: flex; align-items: center; gap: calc(12px * var(--s, 1)); width: 100%; font-size: calc(28px * var(--s, 1)); font-weight: 700; margin: calc(14px * var(--s, 1)) 0 calc(8px * var(--s, 1)); }
+  .view--half_vertical { display: flex; flex-direction: column; flex: 1; align-items: stretch; width: 100%; }
+  .view--half_vertical .flight-top { margin-bottom: calc(64px * var(--s, 1)); }
+  .view--half_vertical .flight-details { margin-top: auto; display: flex; flex-direction: column; gap: calc(16px * var(--s, 1)); }
+  .view--half_vertical .flight-stats { margin-top: calc(64px * var(--s, 1)); font-size: calc(14px * var(--s, 1)); gap: calc(10px * var(--s, 1)); justify-content: space-between; }
+  .view--half_vertical .flight-route { width:100%; margin: 0; }
+  .view--half_vertical .stat-item { display: flex; flex-direction: column; align-items: center; }
+  .view--half_vertical .stat-value { font-size: calc(16px * var(--s, 1)); font-weight: 700; }
+  .view--half_horizontal .flight-top .flight-route { grid-column: 1 / -1; grid-row: 2; margin: calc(6px * var(--s, 1)) 0 0; font-size: calc(22px * var(--s, 1)); }
+  .view--half_horizontal .flight-top .flight-stats { grid-column: 2; grid-row: 1; flex-direction: column; align-items: flex-start; justify-self: center; gap: calc(2px * var(--s, 1)); font-size: calc(16px * var(--s, 1)); margin-top: 0; }
+  .view--half_horizontal .flight-stat-aircraft { font-weight: 600; }
+  .view--half_horizontal .airline-name { font-size: calc(20px * var(--s, 1)); }
+  .view--half_horizontal .flight-number { font-size: calc(30px * var(--s, 1)); }
+  .view--half_horizontal .flight-aircraft { display: none; }
+  .view--half_horizontal .flight-status { font-size: calc(18px * var(--s, 1)); }
+  .view--half_horizontal .route-plane { font-size: calc(28px * var(--s, 1)); }
+  .route-line { flex: 1; height: calc(2px * var(--s, 1)); background: black; position: relative; }
+  .route-line-flown { height: calc(3px * var(--s, 1)); background: black; }
+  .route-line-remaining { height: 0; background: none; border-top: calc(3px * var(--s, 1)) dotted black; }
+  .route-plane { font-size: calc(48px * var(--s, 1)); line-height: 1; }
+  .flight-stats { display: flex; justify-content: space-between; font-size: calc(24px * var(--s, 1)); margin-top: calc(7px * var(--s, 1)); }
+  .stat-label { font-weight: 700; }
+  .airline-logo { width: 100%; max-width: calc(320px * var(--s, 1)); max-height: calc(140px * var(--s, 1)); object-fit: contain; }
+</style>
+<div class="view view--full">
+  <div class="layout">
+    <div class="columns">
+      <div class="column">
+        <div class="markdown">
+          
+  <div class="flight-card">
+    <div class="flight-top">
+      <img class="image-dither airline-logo" src="data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'320'%20height%3D'140'%3E%3Crect%20width%3D'318'%20height%3D'138'%20x%3D'1'%20y%3D'1'%20fill%3D'none'%20stroke%3D'black'%20stroke-width%3D'2'%2F%3E%3Ctext%20x%3D'160'%20y%3D'62'%20font-family%3D'sans-serif'%20font-size%3D'30'%20font-weight%3D'800'%20text-anchor%3D'middle'%3EUNITED%3C%2Ftext%3E%3Ctext%20x%3D'160'%20y%3D'98'%20font-family%3D'sans-serif'%20font-size%3D'30'%20font-weight%3D'800'%20text-anchor%3D'middle'%3EAIRLINES%3C%2Ftext%3E%3C%2Fsvg%3E" onerror="this.style.display='none'" />
+      <div class="flight-meta">
+        <span class="airline-name">United Airlines</span>
+        <span class="flight-number">UA 1074</span>
+        <span class="flight-aircraft">Boeing 737 MAX 9</span>
+        <span class="flight-status">Cruising</span>
+      </div>
+    </div>
+    <div class="flight-arc-wrap">
+      <div class="arc-end">
+        <span class="arc-code">BOS</span>
+        <span class="arc-time">08:12</span>
+      </div>
+      <svg class="arc-svg" viewBox="0 0 600 142" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+      <path d="M393.5,46.1 Q479.8,64.8 566,118" fill="none" stroke="black" stroke-width="4" stroke-linecap="round" stroke-dasharray="1 11" />
+      <path d="M34,118 Q198.9,16.3 363.8,40.7" fill="none" stroke="black" stroke-width="5" stroke-linecap="round" />
+      <circle cx="34" cy="118" r="6" fill="black" />
+      <circle cx="566" cy="118" r="6" fill="white" stroke="black" stroke-width="3" />
+      <g transform="translate(363.8,40.7) rotate(8.4)"><text text-anchor="middle" dominant-baseline="central" font-size="48" fill="black">✈</text></g>
+    </svg>
+      <div class="arc-end">
+        <span class="arc-code">SFO</span>
+        <span class="arc-time">14:36</span>
+      </div>
+    </div>
+    <div class="stat-tiles">
+      <div class="stat-tile"><span class="stat-tile-label">ALT</span><span class="stat-tile-value">37,000 ft</span></div><div class="stat-tile"><span class="stat-tile-label">SPD</span><span class="stat-tile-value">503 mph</span></div><div class="stat-tile"><span class="stat-tile-label">HDG</span><span class="stat-tile-value">251° W</span></div><div class="stat-tile"><span class="stat-tile-label">ETA</span><span class="stat-tile-value">14:36</span></div>
+    </div>
+  </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="title_bar">
+  <span class="title">Flight Tracker</span>
+  <span class="instance">Updated recently</span>
+</div>
+      </div>
+    </figure>
+    <figure>
+      <figcaption>half_horizontal — 800×240</figcaption>
+      <div class="screen " style="width:800px;height:240px">
+        <style>
+  .flight-card { --s: 1; }
+  .screen--lg .flight-card { --s: 1.3; }
+
+  /* full variant: hero arc + stat tiles. Stretch the framework chain so the
+     card can distribute its blocks top-to-bottom and fill the taller X screen. */
+  .view--full, .view--full .layout, .view--full .columns, .view--full .column, .view--full .markdown { display: flex; flex-direction: column; flex: 1; width: 100%; }
+  .view--full .flight-card { justify-content: space-between; padding: calc(20px * var(--s, 1)) calc(40px * var(--s, 1)); }
+  .view--full .flight-top { align-items: center; }
+  .flight-arc-wrap { display: flex; align-items: center; gap: calc(10px * var(--s, 1)); width: 100%; }
+  .arc-end { display: flex; flex-direction: column; align-items: center; min-width: calc(96px * var(--s, 1)); }
+  .arc-code { font-size: calc(40px * var(--s, 1)); font-weight: 800; line-height: 1; }
+  .arc-time { font-size: calc(18px * var(--s, 1)); font-weight: 600; color: #333; margin-top: calc(4px * var(--s, 1)); }
+  .arc-svg { flex: 1 1 0; min-width: 0; height: auto; display: block; overflow: visible; }
+  .stat-tiles { display: flex; gap: calc(12px * var(--s, 1)); width: 100%; }
+  .stat-tile { flex: 1; border: calc(2px * var(--s, 1)) solid black; border-radius: calc(10px * var(--s, 1)); padding: calc(10px * var(--s, 1)) calc(6px * var(--s, 1)); display: flex; flex-direction: column; align-items: center; gap: calc(3px * var(--s, 1)); }
+  .stat-tile-label { font-size: calc(15px * var(--s, 1)); font-weight: 700; letter-spacing: 1.5px; }
+  .stat-tile-value { font-size: calc(26px * var(--s, 1)); font-weight: 800; }
+
+  .flight-card { margin: calc(8px * var(--s, 1)) 0; padding: 0; font-family: 'IBM Plex Sans', 'SF Pro Text', 'Segoe UI', sans-serif; display: flex; flex-direction: column; flex: 1; }
+  .flight-details { margin-top: 0; }
+  .flight-top { display: flex; align-items: center; gap: calc(20px * var(--s, 1)); width: 100%; }
+  .view--half_horizontal .flight-top { display: grid; grid-template-columns: auto 1fr auto; grid-template-rows: auto auto; align-items: center; column-gap: calc(16px * var(--s, 1)); row-gap: calc(2px * var(--s, 1)); }
+  .view--half_horizontal .airline-logo { grid-column: 1; grid-row: 1; align-self: center; }
+  .view--half_horizontal .flight-meta { grid-column: 3; grid-row: 1; }
+  .flight-meta { display: flex; flex-direction: column; gap: calc(5px * var(--s, 1)); align-items: flex-end; text-align: right; margin-left: auto; }
+  .airline-name { font-size: calc(24px * var(--s, 1)); font-weight: 700; letter-spacing: 0.2px; }
+  .flight-number { font-size: calc(34px * var(--s, 1)); font-weight: 800; }
+  .flight-aircraft { font-size: calc(17px * var(--s, 1)); font-weight: 500; color: #444; }
+  .flight-status { font-size: calc(20px * var(--s, 1)); font-weight: 600; }
+  .flight-route { display: flex; align-items: center; gap: calc(12px * var(--s, 1)); width: 100%; font-size: calc(28px * var(--s, 1)); font-weight: 700; margin: calc(14px * var(--s, 1)) 0 calc(8px * var(--s, 1)); }
+  .view--half_vertical { display: flex; flex-direction: column; flex: 1; align-items: stretch; width: 100%; }
+  .view--half_vertical .flight-top { margin-bottom: calc(64px * var(--s, 1)); }
+  .view--half_vertical .flight-details { margin-top: auto; display: flex; flex-direction: column; gap: calc(16px * var(--s, 1)); }
+  .view--half_vertical .flight-stats { margin-top: calc(64px * var(--s, 1)); font-size: calc(14px * var(--s, 1)); gap: calc(10px * var(--s, 1)); justify-content: space-between; }
+  .view--half_vertical .flight-route { width:100%; margin: 0; }
+  .view--half_vertical .stat-item { display: flex; flex-direction: column; align-items: center; }
+  .view--half_vertical .stat-value { font-size: calc(16px * var(--s, 1)); font-weight: 700; }
+  .view--half_horizontal .flight-top .flight-route { grid-column: 1 / -1; grid-row: 2; margin: calc(6px * var(--s, 1)) 0 0; font-size: calc(22px * var(--s, 1)); }
+  .view--half_horizontal .flight-top .flight-stats { grid-column: 2; grid-row: 1; flex-direction: column; align-items: flex-start; justify-self: center; gap: calc(2px * var(--s, 1)); font-size: calc(16px * var(--s, 1)); margin-top: 0; }
+  .view--half_horizontal .flight-stat-aircraft { font-weight: 600; }
+  .view--half_horizontal .airline-name { font-size: calc(20px * var(--s, 1)); }
+  .view--half_horizontal .flight-number { font-size: calc(30px * var(--s, 1)); }
+  .view--half_horizontal .flight-aircraft { display: none; }
+  .view--half_horizontal .flight-status { font-size: calc(18px * var(--s, 1)); }
+  .view--half_horizontal .route-plane { font-size: calc(28px * var(--s, 1)); }
+  .route-line { flex: 1; height: calc(2px * var(--s, 1)); background: black; position: relative; }
+  .route-line-flown { height: calc(3px * var(--s, 1)); background: black; }
+  .route-line-remaining { height: 0; background: none; border-top: calc(3px * var(--s, 1)) dotted black; }
+  .route-plane { font-size: calc(36px * var(--s, 1)); line-height: 1; }
+  .flight-stats { display: flex; gap: calc(26px * var(--s, 1)); font-size: calc(20px * var(--s, 1)); margin-top: calc(7px * var(--s, 1)); }
+  .stat-label { font-weight: 700; }
+  .airline-logo { width: 100%; max-width: calc(220px * var(--s, 1)); max-height: calc(100px * var(--s, 1)); object-fit: contain; }
+</style>
+<div class="view view--half_horizontal">
+  <div class="layout">
+    <div class="columns">
+      <div class="column">
+        <div class="markdown">
+          
+  <div class="flight-card">
+    <div class="flight-top">
+      <img class="image-dither airline-logo" src="data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'320'%20height%3D'140'%3E%3Crect%20width%3D'318'%20height%3D'138'%20x%3D'1'%20y%3D'1'%20fill%3D'none'%20stroke%3D'black'%20stroke-width%3D'2'%2F%3E%3Ctext%20x%3D'160'%20y%3D'62'%20font-family%3D'sans-serif'%20font-size%3D'30'%20font-weight%3D'800'%20text-anchor%3D'middle'%3EUNITED%3C%2Ftext%3E%3Ctext%20x%3D'160'%20y%3D'98'%20font-family%3D'sans-serif'%20font-size%3D'30'%20font-weight%3D'800'%20text-anchor%3D'middle'%3EAIRLINES%3C%2Ftext%3E%3C%2Fsvg%3E" onerror="this.style.display='none'" />
+      <div class="flight-meta">
+        <span class="airline-name">United Airlines</span>
+        <span class="flight-number">UA 1074</span>
+        <span class="flight-aircraft">Boeing 737 MAX 9</span>
+        <span class="flight-status">Cruising</span>
+      </div>
+      
+    <div class="flight-route">
+      <span>BOS</span>
+      <span class="route-line route-line-flown" style="flex: 62;"></span>
+      <span class="route-plane">✈</span>
+      <span class="route-line route-line-remaining" style="flex: 38;"></span>
+      <span>SFO</span>
+    </div>
+      
+    <div class="flight-stats">
+      <span class="stat-item flight-stat-aircraft">Boeing 737 MAX 9</span>
+      <span class="stat-item"><span class="stat-label">ALT:</span> <span class="stat-value">37,000 ft</span></span>
+      <span class="stat-item"><span class="stat-label">SPD:</span> <span class="stat-value">503 mph</span></span>
+      <span class="stat-item"><span class="stat-label">HDG:</span> <span class="stat-value">251° W</span></span>
+      <span class="stat-item"><span class="stat-label">ETA:</span> <span class="stat-value">14:36</span></span>
+    </div>
+    </div>
+    
+  </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="title_bar">
+  <span class="title">Flight Tracker</span>
+  <span class="instance">Updated recently</span>
+</div>
+      </div>
+    </figure>
+    <figure>
+      <figcaption>half_vertical — 400×480</figcaption>
+      <div class="screen " style="width:400px;height:480px">
+        <style>
+  .flight-card { --s: 1; }
+  .screen--lg .flight-card { --s: 1.3; }
+
+  /* full variant: hero arc + stat tiles. Stretch the framework chain so the
+     card can distribute its blocks top-to-bottom and fill the taller X screen. */
+  .view--full, .view--full .layout, .view--full .columns, .view--full .column, .view--full .markdown { display: flex; flex-direction: column; flex: 1; width: 100%; }
+  .view--full .flight-card { justify-content: space-between; padding: calc(20px * var(--s, 1)) calc(40px * var(--s, 1)); }
+  .view--full .flight-top { align-items: center; }
+  .flight-arc-wrap { display: flex; align-items: center; gap: calc(10px * var(--s, 1)); width: 100%; }
+  .arc-end { display: flex; flex-direction: column; align-items: center; min-width: calc(96px * var(--s, 1)); }
+  .arc-code { font-size: calc(40px * var(--s, 1)); font-weight: 800; line-height: 1; }
+  .arc-time { font-size: calc(18px * var(--s, 1)); font-weight: 600; color: #333; margin-top: calc(4px * var(--s, 1)); }
+  .arc-svg { flex: 1 1 0; min-width: 0; height: auto; display: block; overflow: visible; }
+  .stat-tiles { display: flex; gap: calc(12px * var(--s, 1)); width: 100%; }
+  .stat-tile { flex: 1; border: calc(2px * var(--s, 1)) solid black; border-radius: calc(10px * var(--s, 1)); padding: calc(10px * var(--s, 1)) calc(6px * var(--s, 1)); display: flex; flex-direction: column; align-items: center; gap: calc(3px * var(--s, 1)); }
+  .stat-tile-label { font-size: calc(15px * var(--s, 1)); font-weight: 700; letter-spacing: 1.5px; }
+  .stat-tile-value { font-size: calc(26px * var(--s, 1)); font-weight: 800; }
+
+  .flight-card { margin: calc(12px * var(--s, 1)) 0 0; padding: 0; font-family: 'IBM Plex Sans', 'SF Pro Text', 'Segoe UI', sans-serif; display: flex; flex-direction: column; flex: 1; }
+  .flight-details { margin-top: 0; }
+  .flight-top { display: flex; align-items: center; gap: calc(20px * var(--s, 1)); width: 100%; }
+  .view--half_horizontal .flight-top { display: grid; grid-template-columns: auto 1fr auto; grid-template-rows: auto auto; align-items: center; column-gap: calc(16px * var(--s, 1)); row-gap: calc(2px * var(--s, 1)); }
+  .view--half_horizontal .airline-logo { grid-column: 1; grid-row: 1; align-self: center; }
+  .view--half_horizontal .flight-meta { grid-column: 3; grid-row: 1; }
+  .flight-meta { display: flex; flex-direction: column; gap: calc(5px * var(--s, 1)); align-items: flex-end; text-align: right; margin-left: auto; }
+  .airline-name { font-size: calc(24px * var(--s, 1)); font-weight: 700; letter-spacing: 0.2px; }
+  .flight-number { font-size: calc(34px * var(--s, 1)); font-weight: 800; }
+  .flight-aircraft { font-size: calc(17px * var(--s, 1)); font-weight: 500; color: #444; }
+  .flight-status { font-size: calc(20px * var(--s, 1)); font-weight: 600; }
+  .flight-route { display: flex; align-items: center; gap: calc(12px * var(--s, 1)); width: 100%; font-size: calc(28px * var(--s, 1)); font-weight: 700; margin: calc(14px * var(--s, 1)) 0 calc(8px * var(--s, 1)); }
+  .view--half_vertical { display: flex; flex-direction: column; flex: 1; align-items: stretch; width: 100%; }
+  .view--half_vertical .flight-top { margin-bottom: calc(64px * var(--s, 1)); }
+  .view--half_vertical .flight-details { margin-top: auto; display: flex; flex-direction: column; gap: calc(16px * var(--s, 1)); }
+  .view--half_vertical .flight-stats { margin-top: calc(64px * var(--s, 1)); font-size: calc(14px * var(--s, 1)); gap: calc(10px * var(--s, 1)); justify-content: space-between; }
+  .view--half_vertical .flight-route { width:100%; margin: 0; }
+  .view--half_vertical .stat-item { display: flex; flex-direction: column; align-items: center; }
+  .view--half_vertical .stat-value { font-size: calc(16px * var(--s, 1)); font-weight: 700; }
+  .view--half_horizontal .flight-top .flight-route { grid-column: 1 / -1; grid-row: 2; margin: calc(6px * var(--s, 1)) 0 0; font-size: calc(22px * var(--s, 1)); }
+  .view--half_horizontal .flight-top .flight-stats { grid-column: 2; grid-row: 1; flex-direction: column; align-items: flex-start; justify-self: center; gap: calc(2px * var(--s, 1)); font-size: calc(16px * var(--s, 1)); margin-top: 0; }
+  .view--half_horizontal .flight-stat-aircraft { font-weight: 600; }
+  .view--half_horizontal .airline-name { font-size: calc(20px * var(--s, 1)); }
+  .view--half_horizontal .flight-number { font-size: calc(30px * var(--s, 1)); }
+  .view--half_horizontal .flight-aircraft { display: none; }
+  .view--half_horizontal .flight-status { font-size: calc(18px * var(--s, 1)); }
+  .view--half_horizontal .route-plane { font-size: calc(28px * var(--s, 1)); }
+  .route-line { flex: 1; height: calc(2px * var(--s, 1)); background: black; position: relative; }
+  .route-line-flown { height: calc(3px * var(--s, 1)); background: black; }
+  .route-line-remaining { height: 0; background: none; border-top: calc(3px * var(--s, 1)) dotted black; }
+  .route-plane { font-size: calc(36px * var(--s, 1)); line-height: 1; }
+  .flight-stats { display: flex; gap: calc(26px * var(--s, 1)); font-size: calc(20px * var(--s, 1)); margin-top: calc(7px * var(--s, 1)); }
+  .stat-label { font-weight: 700; }
+  .airline-logo { width: 100%; max-width: calc(200px * var(--s, 1)); max-height: calc(90px * var(--s, 1)); object-fit: contain; }
+</style>
+<div class="view view--half_vertical">
+  <div class="layout">
+    <div class="columns">
+      <div class="column">
+        <div class="markdown">
+          
+  <div class="flight-card">
+    <div class="flight-top">
+      <img class="image-dither airline-logo" src="data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'320'%20height%3D'140'%3E%3Crect%20width%3D'318'%20height%3D'138'%20x%3D'1'%20y%3D'1'%20fill%3D'none'%20stroke%3D'black'%20stroke-width%3D'2'%2F%3E%3Ctext%20x%3D'160'%20y%3D'62'%20font-family%3D'sans-serif'%20font-size%3D'30'%20font-weight%3D'800'%20text-anchor%3D'middle'%3EUNITED%3C%2Ftext%3E%3Ctext%20x%3D'160'%20y%3D'98'%20font-family%3D'sans-serif'%20font-size%3D'30'%20font-weight%3D'800'%20text-anchor%3D'middle'%3EAIRLINES%3C%2Ftext%3E%3C%2Fsvg%3E" onerror="this.style.display='none'" />
+      <div class="flight-meta">
+        <span class="airline-name">United Airlines</span>
+        <span class="flight-number">UA 1074</span>
+        <span class="flight-aircraft">Boeing 737 MAX 9</span>
+        <span class="flight-status">Cruising</span>
+      </div>
+      
+      
+    </div>
+    <div class="flight-details">
+    <div class="flight-stats">
+      
+      <span class="stat-item"><span class="stat-label">ALT:</span> <span class="stat-value">37,000 ft</span></span>
+      <span class="stat-item"><span class="stat-label">SPD:</span> <span class="stat-value">503 mph</span></span>
+      <span class="stat-item"><span class="stat-label">HDG:</span> <span class="stat-value">251° W</span></span>
+      <span class="stat-item"><span class="stat-label">ETA:</span> <span class="stat-value">14:36</span></span>
+    </div>
+    <div class="flight-route">
+      <span>BOS</span>
+      <span class="route-line route-line-flown" style="flex: 62;"></span>
+      <span class="route-plane">✈</span>
+      <span class="route-line route-line-remaining" style="flex: 38;"></span>
+      <span>SFO</span>
+    </div></div>
+  </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="title_bar">
+  <span class="title">Flight Tracker</span>
+  <span class="instance">Updated recently</span>
+</div>
+      </div>
+    </figure>
+    <figure>
+      <figcaption>quadrant — 400×240</figcaption>
+      <div class="screen " style="width:400px;height:240px">
+        <style>
+  .flight-card { --s: 1; }
+  .screen--lg .flight-card { --s: 1.3; }
+
+  /* full variant: hero arc + stat tiles. Stretch the framework chain so the
+     card can distribute its blocks top-to-bottom and fill the taller X screen. */
+  .view--full, .view--full .layout, .view--full .columns, .view--full .column, .view--full .markdown { display: flex; flex-direction: column; flex: 1; width: 100%; }
+  .view--full .flight-card { justify-content: space-between; padding: calc(20px * var(--s, 1)) calc(40px * var(--s, 1)); }
+  .view--full .flight-top { align-items: center; }
+  .flight-arc-wrap { display: flex; align-items: center; gap: calc(10px * var(--s, 1)); width: 100%; }
+  .arc-end { display: flex; flex-direction: column; align-items: center; min-width: calc(96px * var(--s, 1)); }
+  .arc-code { font-size: calc(40px * var(--s, 1)); font-weight: 800; line-height: 1; }
+  .arc-time { font-size: calc(18px * var(--s, 1)); font-weight: 600; color: #333; margin-top: calc(4px * var(--s, 1)); }
+  .arc-svg { flex: 1 1 0; min-width: 0; height: auto; display: block; overflow: visible; }
+  .stat-tiles { display: flex; gap: calc(12px * var(--s, 1)); width: 100%; }
+  .stat-tile { flex: 1; border: calc(2px * var(--s, 1)) solid black; border-radius: calc(10px * var(--s, 1)); padding: calc(10px * var(--s, 1)) calc(6px * var(--s, 1)); display: flex; flex-direction: column; align-items: center; gap: calc(3px * var(--s, 1)); }
+  .stat-tile-label { font-size: calc(15px * var(--s, 1)); font-weight: 700; letter-spacing: 1.5px; }
+  .stat-tile-value { font-size: calc(26px * var(--s, 1)); font-weight: 800; }
+
+  .flight-card { margin: calc(6px * var(--s, 1)) calc(8px * var(--s, 1)); padding: 0; font-family: 'IBM Plex Sans', 'SF Pro Text', 'Segoe UI', sans-serif; display: flex; flex-direction: column; flex: 1; }
+  .flight-details { margin-top: 0; }
+  .flight-top { display: flex; align-items: center; gap: calc(12px * var(--s, 1)); width: 100%; }
+  .view--half_horizontal .flight-top { display: grid; grid-template-columns: auto 1fr auto; grid-template-rows: auto auto; align-items: center; column-gap: calc(16px * var(--s, 1)); row-gap: calc(2px * var(--s, 1)); }
+  .view--half_horizontal .airline-logo { grid-column: 1; grid-row: 1; align-self: center; }
+  .view--half_horizontal .flight-meta { grid-column: 3; grid-row: 1; }
+  .flight-meta { display: flex; flex-direction: column; gap: calc(3px * var(--s, 1)); align-items: flex-end; text-align: right; margin-left: auto; }
+  .airline-name { font-size: calc(18px * var(--s, 1)); font-weight: 700; letter-spacing: 0.2px; }
+  .flight-number { font-size: calc(26px * var(--s, 1)); font-weight: 800; }
+  .flight-aircraft { font-size: calc(14px * var(--s, 1)); font-weight: 500; color: #444; }
+  .flight-status { font-size: calc(16px * var(--s, 1)); font-weight: 600; }
+  .flight-route { display: flex; align-items: center; gap: calc(12px * var(--s, 1)); width: 100%; font-size: calc(20px * var(--s, 1)); font-weight: 700; margin: calc(8px * var(--s, 1)) 0 calc(5px * var(--s, 1)); }
+  .view--half_vertical { display: flex; flex-direction: column; flex: 1; align-items: stretch; width: 100%; }
+  .view--half_vertical .flight-top { margin-bottom: calc(64px * var(--s, 1)); }
+  .view--half_vertical .flight-details { margin-top: auto; display: flex; flex-direction: column; gap: calc(16px * var(--s, 1)); }
+  .view--half_vertical .flight-stats { margin-top: calc(64px * var(--s, 1)); font-size: calc(14px * var(--s, 1)); gap: calc(10px * var(--s, 1)); justify-content: space-between; }
+  .view--half_vertical .flight-route { width:100%; margin: 0; }
+  .view--half_vertical .stat-item { display: flex; flex-direction: column; align-items: center; }
+  .view--half_vertical .stat-value { font-size: calc(16px * var(--s, 1)); font-weight: 700; }
+  .view--half_horizontal .flight-top .flight-route { grid-column: 1 / -1; grid-row: 2; margin: calc(6px * var(--s, 1)) 0 0; font-size: calc(22px * var(--s, 1)); }
+  .view--half_horizontal .flight-top .flight-stats { grid-column: 2; grid-row: 1; flex-direction: column; align-items: flex-start; justify-self: center; gap: calc(2px * var(--s, 1)); font-size: calc(16px * var(--s, 1)); margin-top: 0; }
+  .view--half_horizontal .flight-stat-aircraft { font-weight: 600; }
+  .view--half_horizontal .airline-name { font-size: calc(20px * var(--s, 1)); }
+  .view--half_horizontal .flight-number { font-size: calc(30px * var(--s, 1)); }
+  .view--half_horizontal .flight-aircraft { display: none; }
+  .view--half_horizontal .flight-status { font-size: calc(18px * var(--s, 1)); }
+  .view--half_horizontal .route-plane { font-size: calc(28px * var(--s, 1)); }
+  .route-line { flex: 1; height: calc(2px * var(--s, 1)); background: black; position: relative; }
+  .route-line-flown { height: calc(3px * var(--s, 1)); background: black; }
+  .route-line-remaining { height: 0; background: none; border-top: calc(3px * var(--s, 1)) dotted black; }
+  .route-plane { font-size: calc(28px * var(--s, 1)); line-height: 1; }
+  .flight-stats { display: flex; gap: calc(14px * var(--s, 1)); font-size: calc(15px * var(--s, 1)); margin-top: calc(3px * var(--s, 1)); }
+  .stat-label { font-weight: 700; }
+  .airline-logo { width: 100%; max-width: calc(160px * var(--s, 1)); max-height: calc(70px * var(--s, 1)); object-fit: contain; }
+</style>
+<div class="view view--quadrant">
+  <div class="layout">
+    <div class="columns">
+      <div class="column">
+        <div class="markdown">
+          
+  <div class="flight-card">
+    <div class="flight-top">
+      <img class="image-dither airline-logo" src="data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'320'%20height%3D'140'%3E%3Crect%20width%3D'318'%20height%3D'138'%20x%3D'1'%20y%3D'1'%20fill%3D'none'%20stroke%3D'black'%20stroke-width%3D'2'%2F%3E%3Ctext%20x%3D'160'%20y%3D'62'%20font-family%3D'sans-serif'%20font-size%3D'30'%20font-weight%3D'800'%20text-anchor%3D'middle'%3EUNITED%3C%2Ftext%3E%3Ctext%20x%3D'160'%20y%3D'98'%20font-family%3D'sans-serif'%20font-size%3D'30'%20font-weight%3D'800'%20text-anchor%3D'middle'%3EAIRLINES%3C%2Ftext%3E%3C%2Fsvg%3E" onerror="this.style.display='none'" />
+      <div class="flight-meta">
+        <span class="airline-name">United Airlines</span>
+        <span class="flight-number">UA 1074</span>
+        <span class="flight-aircraft">Boeing 737 MAX 9</span>
+        <span class="flight-status">Cruising</span>
+      </div>
+      
+      
+    </div>
+    <div class="flight-details">
+    <div class="flight-route">
+      <span>BOS</span>
+      <span class="route-line route-line-flown" style="flex: 62;"></span>
+      <span class="route-plane">✈</span>
+      <span class="route-line route-line-remaining" style="flex: 38;"></span>
+      <span>SFO</span>
+    </div></div>
+  </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="title_bar">
+  <span class="title">Flight Tracker</span>
+  <span class="instance">Updated recently</span>
+</div>
+      </div>
+    </figure></div>
+  </section>
+  <section>
+    <h2>TRMNL X (screen--v2) — 1040×780</h2>
+    <div class="grid">
+    <figure>
+      <figcaption>full — 1040×780</figcaption>
+      <div class="screen screen--lg" style="width:1040px;height:780px">
+        <style>
+  .flight-card { --s: 1; }
+  .screen--lg .flight-card { --s: 1.3; }
+
+  /* full variant: hero arc + stat tiles. Stretch the framework chain so the
+     card can distribute its blocks top-to-bottom and fill the taller X screen. */
+  .view--full, .view--full .layout, .view--full .columns, .view--full .column, .view--full .markdown { display: flex; flex-direction: column; flex: 1; width: 100%; }
+  .view--full .flight-card { justify-content: space-between; padding: calc(20px * var(--s, 1)) calc(40px * var(--s, 1)); }
+  .view--full .flight-top { align-items: center; }
+  .flight-arc-wrap { display: flex; align-items: center; gap: calc(10px * var(--s, 1)); width: 100%; }
+  .arc-end { display: flex; flex-direction: column; align-items: center; min-width: calc(96px * var(--s, 1)); }
+  .arc-code { font-size: calc(40px * var(--s, 1)); font-weight: 800; line-height: 1; }
+  .arc-time { font-size: calc(18px * var(--s, 1)); font-weight: 600; color: #333; margin-top: calc(4px * var(--s, 1)); }
+  .arc-svg { flex: 1 1 0; min-width: 0; height: auto; display: block; overflow: visible; }
+  .stat-tiles { display: flex; gap: calc(12px * var(--s, 1)); width: 100%; }
+  .stat-tile { flex: 1; border: calc(2px * var(--s, 1)) solid black; border-radius: calc(10px * var(--s, 1)); padding: calc(10px * var(--s, 1)) calc(6px * var(--s, 1)); display: flex; flex-direction: column; align-items: center; gap: calc(3px * var(--s, 1)); }
+  .stat-tile-label { font-size: calc(15px * var(--s, 1)); font-weight: 700; letter-spacing: 1.5px; }
+  .stat-tile-value { font-size: calc(26px * var(--s, 1)); font-weight: 800; }
+
+  .flight-card { margin: 0; padding: calc(12px * var(--s, 1)) calc(24px * var(--s, 1)); font-family: 'IBM Plex Sans', 'SF Pro Text', 'Segoe UI', sans-serif; display: flex; flex-direction: column; flex: 1; }
+  .flight-details { margin-top: calc(60px * var(--s, 1)); }
+  .flight-top { display: flex; align-items: center; gap: calc(20px * var(--s, 1)); width: 100%; }
+  .view--half_horizontal .flight-top { display: grid; grid-template-columns: auto 1fr auto; grid-template-rows: auto auto; align-items: center; column-gap: calc(16px * var(--s, 1)); row-gap: calc(2px * var(--s, 1)); }
+  .view--half_horizontal .airline-logo { grid-column: 1; grid-row: 1; align-self: center; }
+  .view--half_horizontal .flight-meta { grid-column: 3; grid-row: 1; }
+  .flight-meta { display: flex; flex-direction: column; gap: calc(5px * var(--s, 1)); align-items: flex-end; text-align: right; margin-left: auto; }
+  .airline-name { font-size: calc(30px * var(--s, 1)); font-weight: 700; letter-spacing: 0.2px; }
+  .flight-number { font-size: calc(44px * var(--s, 1)); font-weight: 800; }
+  .flight-aircraft { font-size: calc(20px * var(--s, 1)); font-weight: 500; color: #444; }
+  .flight-status { font-size: calc(24px * var(--s, 1)); font-weight: 600; }
+  .flight-route { display: flex; align-items: center; gap: calc(12px * var(--s, 1)); width: 100%; font-size: calc(28px * var(--s, 1)); font-weight: 700; margin: calc(14px * var(--s, 1)) 0 calc(8px * var(--s, 1)); }
+  .view--half_vertical { display: flex; flex-direction: column; flex: 1; align-items: stretch; width: 100%; }
+  .view--half_vertical .flight-top { margin-bottom: calc(64px * var(--s, 1)); }
+  .view--half_vertical .flight-details { margin-top: auto; display: flex; flex-direction: column; gap: calc(16px * var(--s, 1)); }
+  .view--half_vertical .flight-stats { margin-top: calc(64px * var(--s, 1)); font-size: calc(14px * var(--s, 1)); gap: calc(10px * var(--s, 1)); justify-content: space-between; }
+  .view--half_vertical .flight-route { width:100%; margin: 0; }
+  .view--half_vertical .stat-item { display: flex; flex-direction: column; align-items: center; }
+  .view--half_vertical .stat-value { font-size: calc(16px * var(--s, 1)); font-weight: 700; }
+  .view--half_horizontal .flight-top .flight-route { grid-column: 1 / -1; grid-row: 2; margin: calc(6px * var(--s, 1)) 0 0; font-size: calc(22px * var(--s, 1)); }
+  .view--half_horizontal .flight-top .flight-stats { grid-column: 2; grid-row: 1; flex-direction: column; align-items: flex-start; justify-self: center; gap: calc(2px * var(--s, 1)); font-size: calc(16px * var(--s, 1)); margin-top: 0; }
+  .view--half_horizontal .flight-stat-aircraft { font-weight: 600; }
+  .view--half_horizontal .airline-name { font-size: calc(20px * var(--s, 1)); }
+  .view--half_horizontal .flight-number { font-size: calc(30px * var(--s, 1)); }
+  .view--half_horizontal .flight-aircraft { display: none; }
+  .view--half_horizontal .flight-status { font-size: calc(18px * var(--s, 1)); }
+  .view--half_horizontal .route-plane { font-size: calc(28px * var(--s, 1)); }
+  .route-line { flex: 1; height: calc(2px * var(--s, 1)); background: black; position: relative; }
+  .route-line-flown { height: calc(3px * var(--s, 1)); background: black; }
+  .route-line-remaining { height: 0; background: none; border-top: calc(3px * var(--s, 1)) dotted black; }
+  .route-plane { font-size: calc(48px * var(--s, 1)); line-height: 1; }
+  .flight-stats { display: flex; justify-content: space-between; font-size: calc(24px * var(--s, 1)); margin-top: calc(7px * var(--s, 1)); }
+  .stat-label { font-weight: 700; }
+  .airline-logo { width: 100%; max-width: calc(320px * var(--s, 1)); max-height: calc(140px * var(--s, 1)); object-fit: contain; }
+</style>
+<div class="view view--full">
+  <div class="layout">
+    <div class="columns">
+      <div class="column">
+        <div class="markdown">
+          
+  <div class="flight-card">
+    <div class="flight-top">
+      <img class="image-dither airline-logo" src="data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'320'%20height%3D'140'%3E%3Crect%20width%3D'318'%20height%3D'138'%20x%3D'1'%20y%3D'1'%20fill%3D'none'%20stroke%3D'black'%20stroke-width%3D'2'%2F%3E%3Ctext%20x%3D'160'%20y%3D'62'%20font-family%3D'sans-serif'%20font-size%3D'30'%20font-weight%3D'800'%20text-anchor%3D'middle'%3EUNITED%3C%2Ftext%3E%3Ctext%20x%3D'160'%20y%3D'98'%20font-family%3D'sans-serif'%20font-size%3D'30'%20font-weight%3D'800'%20text-anchor%3D'middle'%3EAIRLINES%3C%2Ftext%3E%3C%2Fsvg%3E" onerror="this.style.display='none'" />
+      <div class="flight-meta">
+        <span class="airline-name">United Airlines</span>
+        <span class="flight-number">UA 1074</span>
+        <span class="flight-aircraft">Boeing 737 MAX 9</span>
+        <span class="flight-status">Cruising</span>
+      </div>
+    </div>
+    <div class="flight-arc-wrap">
+      <div class="arc-end">
+        <span class="arc-code">BOS</span>
+        <span class="arc-time">08:12</span>
+      </div>
+      <svg class="arc-svg" viewBox="0 0 600 142" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+      <path d="M393.5,46.1 Q479.8,64.8 566,118" fill="none" stroke="black" stroke-width="4" stroke-linecap="round" stroke-dasharray="1 11" />
+      <path d="M34,118 Q198.9,16.3 363.8,40.7" fill="none" stroke="black" stroke-width="5" stroke-linecap="round" />
+      <circle cx="34" cy="118" r="6" fill="black" />
+      <circle cx="566" cy="118" r="6" fill="white" stroke="black" stroke-width="3" />
+      <g transform="translate(363.8,40.7) rotate(8.4)"><text text-anchor="middle" dominant-baseline="central" font-size="48" fill="black">✈</text></g>
+    </svg>
+      <div class="arc-end">
+        <span class="arc-code">SFO</span>
+        <span class="arc-time">14:36</span>
+      </div>
+    </div>
+    <div class="stat-tiles">
+      <div class="stat-tile"><span class="stat-tile-label">ALT</span><span class="stat-tile-value">37,000 ft</span></div><div class="stat-tile"><span class="stat-tile-label">SPD</span><span class="stat-tile-value">503 mph</span></div><div class="stat-tile"><span class="stat-tile-label">HDG</span><span class="stat-tile-value">251° W</span></div><div class="stat-tile"><span class="stat-tile-label">ETA</span><span class="stat-tile-value">14:36</span></div>
+    </div>
+  </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="title_bar">
+  <span class="title">Flight Tracker</span>
+  <span class="instance">Updated recently</span>
+</div>
+      </div>
+    </figure>
+    <figure>
+      <figcaption>half_horizontal — 1040×390</figcaption>
+      <div class="screen screen--lg" style="width:1040px;height:390px">
+        <style>
+  .flight-card { --s: 1; }
+  .screen--lg .flight-card { --s: 1.3; }
+
+  /* full variant: hero arc + stat tiles. Stretch the framework chain so the
+     card can distribute its blocks top-to-bottom and fill the taller X screen. */
+  .view--full, .view--full .layout, .view--full .columns, .view--full .column, .view--full .markdown { display: flex; flex-direction: column; flex: 1; width: 100%; }
+  .view--full .flight-card { justify-content: space-between; padding: calc(20px * var(--s, 1)) calc(40px * var(--s, 1)); }
+  .view--full .flight-top { align-items: center; }
+  .flight-arc-wrap { display: flex; align-items: center; gap: calc(10px * var(--s, 1)); width: 100%; }
+  .arc-end { display: flex; flex-direction: column; align-items: center; min-width: calc(96px * var(--s, 1)); }
+  .arc-code { font-size: calc(40px * var(--s, 1)); font-weight: 800; line-height: 1; }
+  .arc-time { font-size: calc(18px * var(--s, 1)); font-weight: 600; color: #333; margin-top: calc(4px * var(--s, 1)); }
+  .arc-svg { flex: 1 1 0; min-width: 0; height: auto; display: block; overflow: visible; }
+  .stat-tiles { display: flex; gap: calc(12px * var(--s, 1)); width: 100%; }
+  .stat-tile { flex: 1; border: calc(2px * var(--s, 1)) solid black; border-radius: calc(10px * var(--s, 1)); padding: calc(10px * var(--s, 1)) calc(6px * var(--s, 1)); display: flex; flex-direction: column; align-items: center; gap: calc(3px * var(--s, 1)); }
+  .stat-tile-label { font-size: calc(15px * var(--s, 1)); font-weight: 700; letter-spacing: 1.5px; }
+  .stat-tile-value { font-size: calc(26px * var(--s, 1)); font-weight: 800; }
+
+  .flight-card { margin: calc(8px * var(--s, 1)) 0; padding: 0; font-family: 'IBM Plex Sans', 'SF Pro Text', 'Segoe UI', sans-serif; display: flex; flex-direction: column; flex: 1; }
+  .flight-details { margin-top: 0; }
+  .flight-top { display: flex; align-items: center; gap: calc(20px * var(--s, 1)); width: 100%; }
+  .view--half_horizontal .flight-top { display: grid; grid-template-columns: auto 1fr auto; grid-template-rows: auto auto; align-items: center; column-gap: calc(16px * var(--s, 1)); row-gap: calc(2px * var(--s, 1)); }
+  .view--half_horizontal .airline-logo { grid-column: 1; grid-row: 1; align-self: center; }
+  .view--half_horizontal .flight-meta { grid-column: 3; grid-row: 1; }
+  .flight-meta { display: flex; flex-direction: column; gap: calc(5px * var(--s, 1)); align-items: flex-end; text-align: right; margin-left: auto; }
+  .airline-name { font-size: calc(24px * var(--s, 1)); font-weight: 700; letter-spacing: 0.2px; }
+  .flight-number { font-size: calc(34px * var(--s, 1)); font-weight: 800; }
+  .flight-aircraft { font-size: calc(17px * var(--s, 1)); font-weight: 500; color: #444; }
+  .flight-status { font-size: calc(20px * var(--s, 1)); font-weight: 600; }
+  .flight-route { display: flex; align-items: center; gap: calc(12px * var(--s, 1)); width: 100%; font-size: calc(28px * var(--s, 1)); font-weight: 700; margin: calc(14px * var(--s, 1)) 0 calc(8px * var(--s, 1)); }
+  .view--half_vertical { display: flex; flex-direction: column; flex: 1; align-items: stretch; width: 100%; }
+  .view--half_vertical .flight-top { margin-bottom: calc(64px * var(--s, 1)); }
+  .view--half_vertical .flight-details { margin-top: auto; display: flex; flex-direction: column; gap: calc(16px * var(--s, 1)); }
+  .view--half_vertical .flight-stats { margin-top: calc(64px * var(--s, 1)); font-size: calc(14px * var(--s, 1)); gap: calc(10px * var(--s, 1)); justify-content: space-between; }
+  .view--half_vertical .flight-route { width:100%; margin: 0; }
+  .view--half_vertical .stat-item { display: flex; flex-direction: column; align-items: center; }
+  .view--half_vertical .stat-value { font-size: calc(16px * var(--s, 1)); font-weight: 700; }
+  .view--half_horizontal .flight-top .flight-route { grid-column: 1 / -1; grid-row: 2; margin: calc(6px * var(--s, 1)) 0 0; font-size: calc(22px * var(--s, 1)); }
+  .view--half_horizontal .flight-top .flight-stats { grid-column: 2; grid-row: 1; flex-direction: column; align-items: flex-start; justify-self: center; gap: calc(2px * var(--s, 1)); font-size: calc(16px * var(--s, 1)); margin-top: 0; }
+  .view--half_horizontal .flight-stat-aircraft { font-weight: 600; }
+  .view--half_horizontal .airline-name { font-size: calc(20px * var(--s, 1)); }
+  .view--half_horizontal .flight-number { font-size: calc(30px * var(--s, 1)); }
+  .view--half_horizontal .flight-aircraft { display: none; }
+  .view--half_horizontal .flight-status { font-size: calc(18px * var(--s, 1)); }
+  .view--half_horizontal .route-plane { font-size: calc(28px * var(--s, 1)); }
+  .route-line { flex: 1; height: calc(2px * var(--s, 1)); background: black; position: relative; }
+  .route-line-flown { height: calc(3px * var(--s, 1)); background: black; }
+  .route-line-remaining { height: 0; background: none; border-top: calc(3px * var(--s, 1)) dotted black; }
+  .route-plane { font-size: calc(36px * var(--s, 1)); line-height: 1; }
+  .flight-stats { display: flex; gap: calc(26px * var(--s, 1)); font-size: calc(20px * var(--s, 1)); margin-top: calc(7px * var(--s, 1)); }
+  .stat-label { font-weight: 700; }
+  .airline-logo { width: 100%; max-width: calc(220px * var(--s, 1)); max-height: calc(100px * var(--s, 1)); object-fit: contain; }
+</style>
+<div class="view view--half_horizontal">
+  <div class="layout">
+    <div class="columns">
+      <div class="column">
+        <div class="markdown">
+          
+  <div class="flight-card">
+    <div class="flight-top">
+      <img class="image-dither airline-logo" src="data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'320'%20height%3D'140'%3E%3Crect%20width%3D'318'%20height%3D'138'%20x%3D'1'%20y%3D'1'%20fill%3D'none'%20stroke%3D'black'%20stroke-width%3D'2'%2F%3E%3Ctext%20x%3D'160'%20y%3D'62'%20font-family%3D'sans-serif'%20font-size%3D'30'%20font-weight%3D'800'%20text-anchor%3D'middle'%3EUNITED%3C%2Ftext%3E%3Ctext%20x%3D'160'%20y%3D'98'%20font-family%3D'sans-serif'%20font-size%3D'30'%20font-weight%3D'800'%20text-anchor%3D'middle'%3EAIRLINES%3C%2Ftext%3E%3C%2Fsvg%3E" onerror="this.style.display='none'" />
+      <div class="flight-meta">
+        <span class="airline-name">United Airlines</span>
+        <span class="flight-number">UA 1074</span>
+        <span class="flight-aircraft">Boeing 737 MAX 9</span>
+        <span class="flight-status">Cruising</span>
+      </div>
+      
+    <div class="flight-route">
+      <span>BOS</span>
+      <span class="route-line route-line-flown" style="flex: 62;"></span>
+      <span class="route-plane">✈</span>
+      <span class="route-line route-line-remaining" style="flex: 38;"></span>
+      <span>SFO</span>
+    </div>
+      
+    <div class="flight-stats">
+      <span class="stat-item flight-stat-aircraft">Boeing 737 MAX 9</span>
+      <span class="stat-item"><span class="stat-label">ALT:</span> <span class="stat-value">37,000 ft</span></span>
+      <span class="stat-item"><span class="stat-label">SPD:</span> <span class="stat-value">503 mph</span></span>
+      <span class="stat-item"><span class="stat-label">HDG:</span> <span class="stat-value">251° W</span></span>
+      <span class="stat-item"><span class="stat-label">ETA:</span> <span class="stat-value">14:36</span></span>
+    </div>
+    </div>
+    
+  </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="title_bar">
+  <span class="title">Flight Tracker</span>
+  <span class="instance">Updated recently</span>
+</div>
+      </div>
+    </figure>
+    <figure>
+      <figcaption>half_vertical — 520×780</figcaption>
+      <div class="screen screen--lg" style="width:520px;height:780px">
+        <style>
+  .flight-card { --s: 1; }
+  .screen--lg .flight-card { --s: 1.3; }
+
+  /* full variant: hero arc + stat tiles. Stretch the framework chain so the
+     card can distribute its blocks top-to-bottom and fill the taller X screen. */
+  .view--full, .view--full .layout, .view--full .columns, .view--full .column, .view--full .markdown { display: flex; flex-direction: column; flex: 1; width: 100%; }
+  .view--full .flight-card { justify-content: space-between; padding: calc(20px * var(--s, 1)) calc(40px * var(--s, 1)); }
+  .view--full .flight-top { align-items: center; }
+  .flight-arc-wrap { display: flex; align-items: center; gap: calc(10px * var(--s, 1)); width: 100%; }
+  .arc-end { display: flex; flex-direction: column; align-items: center; min-width: calc(96px * var(--s, 1)); }
+  .arc-code { font-size: calc(40px * var(--s, 1)); font-weight: 800; line-height: 1; }
+  .arc-time { font-size: calc(18px * var(--s, 1)); font-weight: 600; color: #333; margin-top: calc(4px * var(--s, 1)); }
+  .arc-svg { flex: 1 1 0; min-width: 0; height: auto; display: block; overflow: visible; }
+  .stat-tiles { display: flex; gap: calc(12px * var(--s, 1)); width: 100%; }
+  .stat-tile { flex: 1; border: calc(2px * var(--s, 1)) solid black; border-radius: calc(10px * var(--s, 1)); padding: calc(10px * var(--s, 1)) calc(6px * var(--s, 1)); display: flex; flex-direction: column; align-items: center; gap: calc(3px * var(--s, 1)); }
+  .stat-tile-label { font-size: calc(15px * var(--s, 1)); font-weight: 700; letter-spacing: 1.5px; }
+  .stat-tile-value { font-size: calc(26px * var(--s, 1)); font-weight: 800; }
+
+  .flight-card { margin: calc(12px * var(--s, 1)) 0 0; padding: 0; font-family: 'IBM Plex Sans', 'SF Pro Text', 'Segoe UI', sans-serif; display: flex; flex-direction: column; flex: 1; }
+  .flight-details { margin-top: 0; }
+  .flight-top { display: flex; align-items: center; gap: calc(20px * var(--s, 1)); width: 100%; }
+  .view--half_horizontal .flight-top { display: grid; grid-template-columns: auto 1fr auto; grid-template-rows: auto auto; align-items: center; column-gap: calc(16px * var(--s, 1)); row-gap: calc(2px * var(--s, 1)); }
+  .view--half_horizontal .airline-logo { grid-column: 1; grid-row: 1; align-self: center; }
+  .view--half_horizontal .flight-meta { grid-column: 3; grid-row: 1; }
+  .flight-meta { display: flex; flex-direction: column; gap: calc(5px * var(--s, 1)); align-items: flex-end; text-align: right; margin-left: auto; }
+  .airline-name { font-size: calc(24px * var(--s, 1)); font-weight: 700; letter-spacing: 0.2px; }
+  .flight-number { font-size: calc(34px * var(--s, 1)); font-weight: 800; }
+  .flight-aircraft { font-size: calc(17px * var(--s, 1)); font-weight: 500; color: #444; }
+  .flight-status { font-size: calc(20px * var(--s, 1)); font-weight: 600; }
+  .flight-route { display: flex; align-items: center; gap: calc(12px * var(--s, 1)); width: 100%; font-size: calc(28px * var(--s, 1)); font-weight: 700; margin: calc(14px * var(--s, 1)) 0 calc(8px * var(--s, 1)); }
+  .view--half_vertical { display: flex; flex-direction: column; flex: 1; align-items: stretch; width: 100%; }
+  .view--half_vertical .flight-top { margin-bottom: calc(64px * var(--s, 1)); }
+  .view--half_vertical .flight-details { margin-top: auto; display: flex; flex-direction: column; gap: calc(16px * var(--s, 1)); }
+  .view--half_vertical .flight-stats { margin-top: calc(64px * var(--s, 1)); font-size: calc(14px * var(--s, 1)); gap: calc(10px * var(--s, 1)); justify-content: space-between; }
+  .view--half_vertical .flight-route { width:100%; margin: 0; }
+  .view--half_vertical .stat-item { display: flex; flex-direction: column; align-items: center; }
+  .view--half_vertical .stat-value { font-size: calc(16px * var(--s, 1)); font-weight: 700; }
+  .view--half_horizontal .flight-top .flight-route { grid-column: 1 / -1; grid-row: 2; margin: calc(6px * var(--s, 1)) 0 0; font-size: calc(22px * var(--s, 1)); }
+  .view--half_horizontal .flight-top .flight-stats { grid-column: 2; grid-row: 1; flex-direction: column; align-items: flex-start; justify-self: center; gap: calc(2px * var(--s, 1)); font-size: calc(16px * var(--s, 1)); margin-top: 0; }
+  .view--half_horizontal .flight-stat-aircraft { font-weight: 600; }
+  .view--half_horizontal .airline-name { font-size: calc(20px * var(--s, 1)); }
+  .view--half_horizontal .flight-number { font-size: calc(30px * var(--s, 1)); }
+  .view--half_horizontal .flight-aircraft { display: none; }
+  .view--half_horizontal .flight-status { font-size: calc(18px * var(--s, 1)); }
+  .view--half_horizontal .route-plane { font-size: calc(28px * var(--s, 1)); }
+  .route-line { flex: 1; height: calc(2px * var(--s, 1)); background: black; position: relative; }
+  .route-line-flown { height: calc(3px * var(--s, 1)); background: black; }
+  .route-line-remaining { height: 0; background: none; border-top: calc(3px * var(--s, 1)) dotted black; }
+  .route-plane { font-size: calc(36px * var(--s, 1)); line-height: 1; }
+  .flight-stats { display: flex; gap: calc(26px * var(--s, 1)); font-size: calc(20px * var(--s, 1)); margin-top: calc(7px * var(--s, 1)); }
+  .stat-label { font-weight: 700; }
+  .airline-logo { width: 100%; max-width: calc(200px * var(--s, 1)); max-height: calc(90px * var(--s, 1)); object-fit: contain; }
+</style>
+<div class="view view--half_vertical">
+  <div class="layout">
+    <div class="columns">
+      <div class="column">
+        <div class="markdown">
+          
+  <div class="flight-card">
+    <div class="flight-top">
+      <img class="image-dither airline-logo" src="data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'320'%20height%3D'140'%3E%3Crect%20width%3D'318'%20height%3D'138'%20x%3D'1'%20y%3D'1'%20fill%3D'none'%20stroke%3D'black'%20stroke-width%3D'2'%2F%3E%3Ctext%20x%3D'160'%20y%3D'62'%20font-family%3D'sans-serif'%20font-size%3D'30'%20font-weight%3D'800'%20text-anchor%3D'middle'%3EUNITED%3C%2Ftext%3E%3Ctext%20x%3D'160'%20y%3D'98'%20font-family%3D'sans-serif'%20font-size%3D'30'%20font-weight%3D'800'%20text-anchor%3D'middle'%3EAIRLINES%3C%2Ftext%3E%3C%2Fsvg%3E" onerror="this.style.display='none'" />
+      <div class="flight-meta">
+        <span class="airline-name">United Airlines</span>
+        <span class="flight-number">UA 1074</span>
+        <span class="flight-aircraft">Boeing 737 MAX 9</span>
+        <span class="flight-status">Cruising</span>
+      </div>
+      
+      
+    </div>
+    <div class="flight-details">
+    <div class="flight-stats">
+      
+      <span class="stat-item"><span class="stat-label">ALT:</span> <span class="stat-value">37,000 ft</span></span>
+      <span class="stat-item"><span class="stat-label">SPD:</span> <span class="stat-value">503 mph</span></span>
+      <span class="stat-item"><span class="stat-label">HDG:</span> <span class="stat-value">251° W</span></span>
+      <span class="stat-item"><span class="stat-label">ETA:</span> <span class="stat-value">14:36</span></span>
+    </div>
+    <div class="flight-route">
+      <span>BOS</span>
+      <span class="route-line route-line-flown" style="flex: 62;"></span>
+      <span class="route-plane">✈</span>
+      <span class="route-line route-line-remaining" style="flex: 38;"></span>
+      <span>SFO</span>
+    </div></div>
+  </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="title_bar">
+  <span class="title">Flight Tracker</span>
+  <span class="instance">Updated recently</span>
+</div>
+      </div>
+    </figure>
+    <figure>
+      <figcaption>quadrant — 520×390</figcaption>
+      <div class="screen screen--lg" style="width:520px;height:390px">
+        <style>
+  .flight-card { --s: 1; }
+  .screen--lg .flight-card { --s: 1.3; }
+
+  /* full variant: hero arc + stat tiles. Stretch the framework chain so the
+     card can distribute its blocks top-to-bottom and fill the taller X screen. */
+  .view--full, .view--full .layout, .view--full .columns, .view--full .column, .view--full .markdown { display: flex; flex-direction: column; flex: 1; width: 100%; }
+  .view--full .flight-card { justify-content: space-between; padding: calc(20px * var(--s, 1)) calc(40px * var(--s, 1)); }
+  .view--full .flight-top { align-items: center; }
+  .flight-arc-wrap { display: flex; align-items: center; gap: calc(10px * var(--s, 1)); width: 100%; }
+  .arc-end { display: flex; flex-direction: column; align-items: center; min-width: calc(96px * var(--s, 1)); }
+  .arc-code { font-size: calc(40px * var(--s, 1)); font-weight: 800; line-height: 1; }
+  .arc-time { font-size: calc(18px * var(--s, 1)); font-weight: 600; color: #333; margin-top: calc(4px * var(--s, 1)); }
+  .arc-svg { flex: 1 1 0; min-width: 0; height: auto; display: block; overflow: visible; }
+  .stat-tiles { display: flex; gap: calc(12px * var(--s, 1)); width: 100%; }
+  .stat-tile { flex: 1; border: calc(2px * var(--s, 1)) solid black; border-radius: calc(10px * var(--s, 1)); padding: calc(10px * var(--s, 1)) calc(6px * var(--s, 1)); display: flex; flex-direction: column; align-items: center; gap: calc(3px * var(--s, 1)); }
+  .stat-tile-label { font-size: calc(15px * var(--s, 1)); font-weight: 700; letter-spacing: 1.5px; }
+  .stat-tile-value { font-size: calc(26px * var(--s, 1)); font-weight: 800; }
+
+  .flight-card { margin: calc(6px * var(--s, 1)) calc(8px * var(--s, 1)); padding: 0; font-family: 'IBM Plex Sans', 'SF Pro Text', 'Segoe UI', sans-serif; display: flex; flex-direction: column; flex: 1; }
+  .flight-details { margin-top: 0; }
+  .flight-top { display: flex; align-items: center; gap: calc(12px * var(--s, 1)); width: 100%; }
+  .view--half_horizontal .flight-top { display: grid; grid-template-columns: auto 1fr auto; grid-template-rows: auto auto; align-items: center; column-gap: calc(16px * var(--s, 1)); row-gap: calc(2px * var(--s, 1)); }
+  .view--half_horizontal .airline-logo { grid-column: 1; grid-row: 1; align-self: center; }
+  .view--half_horizontal .flight-meta { grid-column: 3; grid-row: 1; }
+  .flight-meta { display: flex; flex-direction: column; gap: calc(3px * var(--s, 1)); align-items: flex-end; text-align: right; margin-left: auto; }
+  .airline-name { font-size: calc(18px * var(--s, 1)); font-weight: 700; letter-spacing: 0.2px; }
+  .flight-number { font-size: calc(26px * var(--s, 1)); font-weight: 800; }
+  .flight-aircraft { font-size: calc(14px * var(--s, 1)); font-weight: 500; color: #444; }
+  .flight-status { font-size: calc(16px * var(--s, 1)); font-weight: 600; }
+  .flight-route { display: flex; align-items: center; gap: calc(12px * var(--s, 1)); width: 100%; font-size: calc(20px * var(--s, 1)); font-weight: 700; margin: calc(8px * var(--s, 1)) 0 calc(5px * var(--s, 1)); }
+  .view--half_vertical { display: flex; flex-direction: column; flex: 1; align-items: stretch; width: 100%; }
+  .view--half_vertical .flight-top { margin-bottom: calc(64px * var(--s, 1)); }
+  .view--half_vertical .flight-details { margin-top: auto; display: flex; flex-direction: column; gap: calc(16px * var(--s, 1)); }
+  .view--half_vertical .flight-stats { margin-top: calc(64px * var(--s, 1)); font-size: calc(14px * var(--s, 1)); gap: calc(10px * var(--s, 1)); justify-content: space-between; }
+  .view--half_vertical .flight-route { width:100%; margin: 0; }
+  .view--half_vertical .stat-item { display: flex; flex-direction: column; align-items: center; }
+  .view--half_vertical .stat-value { font-size: calc(16px * var(--s, 1)); font-weight: 700; }
+  .view--half_horizontal .flight-top .flight-route { grid-column: 1 / -1; grid-row: 2; margin: calc(6px * var(--s, 1)) 0 0; font-size: calc(22px * var(--s, 1)); }
+  .view--half_horizontal .flight-top .flight-stats { grid-column: 2; grid-row: 1; flex-direction: column; align-items: flex-start; justify-self: center; gap: calc(2px * var(--s, 1)); font-size: calc(16px * var(--s, 1)); margin-top: 0; }
+  .view--half_horizontal .flight-stat-aircraft { font-weight: 600; }
+  .view--half_horizontal .airline-name { font-size: calc(20px * var(--s, 1)); }
+  .view--half_horizontal .flight-number { font-size: calc(30px * var(--s, 1)); }
+  .view--half_horizontal .flight-aircraft { display: none; }
+  .view--half_horizontal .flight-status { font-size: calc(18px * var(--s, 1)); }
+  .view--half_horizontal .route-plane { font-size: calc(28px * var(--s, 1)); }
+  .route-line { flex: 1; height: calc(2px * var(--s, 1)); background: black; position: relative; }
+  .route-line-flown { height: calc(3px * var(--s, 1)); background: black; }
+  .route-line-remaining { height: 0; background: none; border-top: calc(3px * var(--s, 1)) dotted black; }
+  .route-plane { font-size: calc(28px * var(--s, 1)); line-height: 1; }
+  .flight-stats { display: flex; gap: calc(14px * var(--s, 1)); font-size: calc(15px * var(--s, 1)); margin-top: calc(3px * var(--s, 1)); }
+  .stat-label { font-weight: 700; }
+  .airline-logo { width: 100%; max-width: calc(160px * var(--s, 1)); max-height: calc(70px * var(--s, 1)); object-fit: contain; }
+</style>
+<div class="view view--quadrant">
+  <div class="layout">
+    <div class="columns">
+      <div class="column">
+        <div class="markdown">
+          
+  <div class="flight-card">
+    <div class="flight-top">
+      <img class="image-dither airline-logo" src="data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'320'%20height%3D'140'%3E%3Crect%20width%3D'318'%20height%3D'138'%20x%3D'1'%20y%3D'1'%20fill%3D'none'%20stroke%3D'black'%20stroke-width%3D'2'%2F%3E%3Ctext%20x%3D'160'%20y%3D'62'%20font-family%3D'sans-serif'%20font-size%3D'30'%20font-weight%3D'800'%20text-anchor%3D'middle'%3EUNITED%3C%2Ftext%3E%3Ctext%20x%3D'160'%20y%3D'98'%20font-family%3D'sans-serif'%20font-size%3D'30'%20font-weight%3D'800'%20text-anchor%3D'middle'%3EAIRLINES%3C%2Ftext%3E%3C%2Fsvg%3E" onerror="this.style.display='none'" />
+      <div class="flight-meta">
+        <span class="airline-name">United Airlines</span>
+        <span class="flight-number">UA 1074</span>
+        <span class="flight-aircraft">Boeing 737 MAX 9</span>
+        <span class="flight-status">Cruising</span>
+      </div>
+      
+      
+    </div>
+    <div class="flight-details">
+    <div class="flight-route">
+      <span>BOS</span>
+      <span class="route-line route-line-flown" style="flex: 62;"></span>
+      <span class="route-plane">✈</span>
+      <span class="route-line route-line-remaining" style="flex: 38;"></span>
+      <span>SFO</span>
+    </div></div>
+  </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="title_bar">
+  <span class="title">Flight Tracker</span>
+  <span class="instance">Updated recently</span>
+</div>
+      </div>
+    </figure></div>
+  </section>
+</body></html>

--- a/src/integrations/aerodatabox/formatters.ts
+++ b/src/integrations/aerodatabox/formatters.ts
@@ -109,6 +109,21 @@ export function renderMarkup(
   .flight-card { --s: 1; }
   .screen--lg .flight-card { --s: 1.3; }
 
+  /* full variant: hero arc + stat tiles. Stretch the framework chain so the
+     card can distribute its blocks top-to-bottom and fill the taller X screen. */
+  .view--full, .view--full .layout, .view--full .columns, .view--full .column, .view--full .markdown { display: flex; flex-direction: column; flex: 1; width: 100%; }
+  .view--full .flight-card { justify-content: space-between; padding: ${s(20)} ${s(40)}; }
+  .view--full .flight-top { align-items: center; }
+  .flight-arc-wrap { display: flex; align-items: center; gap: ${s(10)}; width: 100%; }
+  .arc-end { display: flex; flex-direction: column; align-items: center; min-width: ${s(96)}; }
+  .arc-code { font-size: ${s(40)}; font-weight: 800; line-height: 1; }
+  .arc-time { font-size: ${s(18)}; font-weight: 600; color: #333; margin-top: ${s(4)}; }
+  .arc-svg { flex: 1 1 0; min-width: 0; height: auto; display: block; overflow: visible; }
+  .stat-tiles { display: flex; gap: ${s(12)}; width: 100%; }
+  .stat-tile { flex: 1; border: ${s(2)} solid black; border-radius: ${s(10)}; padding: ${s(10)} ${s(6)}; display: flex; flex-direction: column; align-items: center; gap: ${s(3)}; }
+  .stat-tile-label { font-size: ${s(15)}; font-weight: 700; letter-spacing: 1.5px; }
+  .stat-tile-value { font-size: ${s(26)}; font-weight: 800; }
+
   .flight-card { margin: ${variant === 'full' ? '0' : variant === 'half_vertical' ? `${s(12)} 0 0` : variant === 'half_horizontal' ? `${s(8)} 0` : `${s(6)} ${s(8)}`}; padding: ${variant === 'full' ? `${s(12)} ${s(24)}` : '0'}; font-family: 'IBM Plex Sans', 'SF Pro Text', 'Segoe UI', sans-serif; display: flex; flex-direction: column; flex: 1; }
   .flight-details { margin-top: ${variant === 'full' ? s(60) : '0'}; }
   .flight-top { display: flex; align-items: center; gap: ${variant === 'quadrant' ? s(12) : s(20)}; width: 100%; }
@@ -137,6 +152,8 @@ export function renderMarkup(
   .view--half_horizontal .flight-status { font-size: ${s(18)}; }
   .view--half_horizontal .route-plane { font-size: ${s(28)}; }
   .route-line { flex: 1; height: ${s(2)}; background: black; position: relative; }
+  .route-line-flown { height: ${s(3)}; background: black; }
+  .route-line-remaining { height: 0; background: none; border-top: ${s(3)} dotted black; }
   .route-plane { font-size: ${variant === 'quadrant' ? s(28) : variant === 'full' ? s(48) : s(36)}; line-height: 1; }
   .flight-stats { display: flex; ${variant === 'full' ? 'justify-content: space-between;' : `gap: ${variant === 'quadrant' ? s(14) : s(26)};`} font-size: ${variant === 'full' ? s(24) : variant === 'quadrant' ? s(15) : s(20)}; margin-top: ${variant === 'quadrant' ? s(3) : s(7)}; }
   .stat-label { font-weight: 700; }
@@ -161,7 +178,111 @@ export function renderMarkup(
 `.trim()
 }
 
+// Build a great-circle-style arc with the plane positioned (and rotated to the
+// path tangent) at progressPct. Flown segment is solid, remaining is dashed.
+// Splitting the quadratic bezier at t via de Casteljau gives both halves exactly.
+function buildArcSvg(progressPct: number | null): string {
+  const P0 = { x: 34, y: 118 }
+  const P1 = { x: 300, y: -46 } // control above the viewBox to deepen the arc
+  const P2 = { x: 566, y: 118 }
+  const lerp = (a: { x: number; y: number }, b: { x: number; y: number }, r: number) => ({
+    x: a.x + (b.x - a.x) * r,
+    y: a.y + (b.y - a.y) * r,
+  })
+
+  const t = progressPct != null ? Math.max(0, Math.min(1, progressPct / 100)) : 0
+  const A = lerp(P0, P1, t)
+  const B = lerp(P1, P2, t)
+  const C = lerp(A, B, t) // point on the curve at t — plane sits here
+
+  // Tangent direction of a quadratic bezier is proportional to (B - A)
+  const angle = (Math.atan2(B.y - A.y, B.x - A.x) * 180) / Math.PI
+
+  // Start the dotted remainder slightly ahead of the plane so the dots don't run under the glyph.
+  // |B'(t)| = 2|B-A| is the curve speed (px per unit t), so advancing ~one plane half-width is 30/speed in t.
+  const speed = 2 * Math.hypot(B.x - A.x, B.y - A.y)
+  const t2 = Math.min(t + (speed > 0 ? Math.min(30 / speed, 0.12) : 0.06), 1)
+  const A2 = lerp(P0, P1, t2)
+  const B2 = lerp(P1, P2, t2)
+  const C2 = lerp(A2, B2, t2)
+
+  const n = (v: number) => v.toFixed(1)
+  const flownPath = t > 0.01 ? `M${P0.x},${P0.y} Q${n(A.x)},${n(A.y)} ${n(C.x)},${n(C.y)}` : ''
+  const remainingPath = t2 < 0.995 ? `M${n(C2.x)},${n(C2.y)} Q${n(B2.x)},${n(B2.y)} ${P2.x},${P2.y}` : ''
+
+  // The ✈ glyph (U+2708) rests pointing east (+x), so rotate by the tangent angle to align its nose with travel
+  return `<svg class="arc-svg" viewBox="0 0 600 142" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+      ${remainingPath ? `<path d="${remainingPath}" fill="none" stroke="black" stroke-width="4" stroke-linecap="round" stroke-dasharray="1 11" />` : ''}
+      ${flownPath ? `<path d="${flownPath}" fill="none" stroke="black" stroke-width="5" stroke-linecap="round" />` : ''}
+      <circle cx="${P0.x}" cy="${P0.y}" r="6" fill="black" />
+      <circle cx="${P2.x}" cy="${P2.y}" r="6" fill="white" stroke="black" stroke-width="3" />
+      <g transform="translate(${n(C.x)},${n(C.y)}) rotate(${n(angle)})"><text text-anchor="middle" dominant-baseline="central" font-size="48" fill="black">✈</text></g>
+    </svg>`
+}
+
+function renderFullCard(f: FlightDisplayData, baseUrl: string): string {
+  const logoUrl = `${baseUrl}/public/radarbox_banners/${encodeURIComponent(f.airlineIcao)}.png`
+  const airlineCode = f.airlineIata || ''
+  const airlineName = AIRLINE_NAMES[airlineCode] ?? (airlineCode || f.flightIata)
+  const flightCode =
+    airlineCode && f.flightIata.startsWith(airlineCode)
+      ? `${airlineCode} ${f.flightIata.slice(airlineCode.length)}`
+      : f.flightIata
+
+  const hasLiveData = f.altitudeFt !== '--' || f.speedMph !== '--' || f.heading !== '--'
+  const altDisplay = `${escapeHtml(f.altitudeFt)}${f.altitudeFt !== '--' && f.altitudeFt !== 'Ground' ? ' ft' : ''}`
+  const spdDisplay = `${escapeHtml(f.speedMph)}${f.speedMph !== '--' ? ' mph' : ''}`
+
+  const tiles = hasLiveData
+    ? [
+        { label: 'ALT', value: altDisplay },
+        { label: 'SPD', value: spdDisplay },
+        { label: 'HDG', value: escapeHtml(f.heading) },
+        { label: 'ETA', value: escapeHtml(f.eta) },
+      ]
+    : [
+        { label: 'DEP', value: escapeHtml(f.depTime) },
+        { label: 'ETA', value: escapeHtml(f.eta) },
+      ]
+
+  const tilesHtml = tiles
+    .map(
+      (t) =>
+        `<div class="stat-tile"><span class="stat-tile-label">${t.label}</span><span class="stat-tile-value">${t.value}</span></div>`
+    )
+    .join('')
+
+  return `
+  <div class="flight-card">
+    <div class="flight-top">
+      <img class="image-dither airline-logo" src="${logoUrl}" onerror="this.style.display='none'" />
+      <div class="flight-meta">
+        <span class="airline-name">${escapeHtml(airlineName)}</span>
+        <span class="flight-number">${escapeHtml(flightCode)}</span>
+        <span class="flight-aircraft">${escapeHtml(f.aircraftModel)}</span>
+        <span class="flight-status">${escapeHtml(f.status)}</span>
+      </div>
+    </div>
+    <div class="flight-arc-wrap">
+      <div class="arc-end">
+        <span class="arc-code">${escapeHtml(f.depAirport || '---')}</span>
+        <span class="arc-time">${escapeHtml(f.depTime)}</span>
+      </div>
+      ${buildArcSvg(f.progressPct)}
+      <div class="arc-end">
+        <span class="arc-code">${escapeHtml(f.arrAirport || '---')}</span>
+        <span class="arc-time">${escapeHtml(f.eta)}</span>
+      </div>
+    </div>
+    <div class="stat-tiles">
+      ${tilesHtml}
+    </div>
+  </div>`
+}
+
 function renderFlightCard(f: FlightDisplayData, variant: MarkupVariant, baseUrl: string): string {
+  if (variant === 'full') return renderFullCard(f, baseUrl)
+
   const logoUrl = `${baseUrl}/public/radarbox_banners/${encodeURIComponent(f.airlineIcao)}.png`
   const showStats = variant !== 'quadrant'
   const showRoute = true
@@ -174,16 +295,19 @@ function renderFlightCard(f: FlightDisplayData, variant: MarkupVariant, baseUrl:
       : f.flightIata
 
   // If we have progress data, use flex ratios to position the plane icon
-  const leftFlex = f.progressPct != null ? Math.max(f.progressPct, 2) : 1
-  const rightFlex = f.progressPct != null ? Math.max(100 - f.progressPct, 2) : 1
+  const hasProgress = f.progressPct != null
+  const leftFlex = hasProgress ? Math.max(f.progressPct!, 2) : 1
+  const rightFlex = hasProgress ? Math.max(100 - f.progressPct!, 2) : 1
+  // Flown segment is solid only when we know progress; otherwise both sides dotted (position unknown)
+  const leftLineClass = hasProgress ? 'route-line route-line-flown' : 'route-line route-line-remaining'
 
   const routeHtml = showRoute
     ? `
     <div class="flight-route">
       <span>${escapeHtml(f.depAirport || '---')}</span>
-      <span class="route-line" style="flex: ${leftFlex};"></span>
+      <span class="${leftLineClass}" style="flex: ${leftFlex};"></span>
       <span class="route-plane">✈</span>
-      <span class="route-line" style="flex: ${rightFlex};"></span>
+      <span class="route-line route-line-remaining" style="flex: ${rightFlex};"></span>
       <span>${escapeHtml(f.arrAirport || '---')}</span>
     </div>`
     : ''


### PR DESCRIPTION
Redesigns the flight tracker `full` variant with a great-circle SVG arc (plane positioned and rotated to the path tangent at `progressPct`, solid flown / dotted remaining) and a bottom row of bordered ALT/SPD/HDG/ETA stat tiles. Fills the whitespace on TRMNL X (`screen--lg`) while degrading cleanly to the regular 800×480 device.

Also applies the solid-flown / dotted-remaining progress treatment to the flat route line in the `half_horizontal`, `half_vertical`, and `quadrant` variants.

Adds `flight-preview.html`, a self-contained harness rendering all four variants at both device sizes for markup iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)