### PR TITLE
Release v1.17.5: shutdown hardening + TRMNL X full-card sizing + CI bumps

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,7 +15,7 @@ jobs:
   build-and-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # ensures full history for changelog generation
 
@@ -36,7 +36,7 @@ jobs:
           echo "tags=$TAGS" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,6 @@
 services:
   subspace-api:
+    init: true
     build: ./
     image: subspace-api:dev
     container_name: subspace-api-dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   subspace-api:
+    init: true
     build: ./
     image: ghcr.io/subtype-space/subspace-api:latest
     container_name: subspace-api

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subspace-api",
-  "version": "1.17.4",
+  "version": "1.17.5",
   "description": "API service for subtype.space",
   "repository": {
     "type": "git",

--- a/scripts/renderFlightPreview.ts
+++ b/scripts/renderFlightPreview.ts
@@ -1,3 +1,5 @@
+// This is a helper script to generate mock HTML representative of TRMNL devices.
+// It should generate all forms, including TRMNL X dimensions
 import { renderMarkup } from "../src/integrations/aerodatabox/formatters.js";
 import { writeFileSync } from "node:fs";
 import { config } from '../src/config.js'
@@ -27,6 +29,13 @@ const SIZES: Record<string, [number, number]> = {
   half_horizontal: [800, 240],
   half_vertical:   [400, 480],
   quadrant:        [400, 240],
+}
+
+const xSIZES: Record<string, [number, number]> = {
+  full:            [1040, 780],
+  half_horizontal: [1040, 390],
+  half_vertical:   [520,  780],
+  quadrant:        [520,  390],
 }
 
 /**
@@ -65,13 +74,15 @@ const baseUrl = new URL(config.auth.mcpServerUrl).origin
 
 const variants = ['full', 'half_horizontal', 'half_vertical', 'quadrant'] as MarkupVariant[]
 const generatedVariants = variants.map(v => {
-    const [w, h] = SIZES[v]
-    return generateVariant(renderMarkup(sampleFlight, v, 0, baseUrl), v, w, h)
+  const [w, h] = SIZES[v]
+  return generateVariant(renderMarkup(sampleFlight, v, 0, baseUrl), v, w, h)
 }).join('')
 
-// TRMNL X: full variant on the larger screen (screen--lg drives --s: 1.3)
-const xFull = generateVariant(renderMarkup(sampleFlight, 'full', 0, baseUrl), 'full', 1040, 780, 'screen--lg')
+const generatedXVariants = variants.map(v => {
+  const [w, h] = xSIZES[v]
+  return generateVariant(renderMarkup(sampleFlight, v, 0, baseUrl), v, w, h, 'screen--lg')
+})
 
 
-writeFileSync('flight-preview.html', generatePage(generatedVariants + xFull))
+writeFileSync('flight-preview.html', generatePage(generatedVariants + generatedXVariants))
 

--- a/src/integrations/aerodatabox/formatters.ts
+++ b/src/integrations/aerodatabox/formatters.ts
@@ -134,6 +134,14 @@ export function renderMarkup(
   .stat-tile-label { font-size: ${s(15)}; font-weight: 700; letter-spacing: 1.5px; }
   .stat-tile-value { font-size: ${s(26)}; font-weight: 800; }
 
+  /* TRMNL X (screen--lg): the taller screen leaves room for a larger logo and
+     header, so bump just those on the full variant (arc + tiles already fill the width). */
+  .screen--lg .view--full .airline-logo { max-width: ${s(370)}; max-height: ${s(165)}; }
+  .screen--lg .view--full .airline-name { font-size: ${s(34)}; }
+  .screen--lg .view--full .flight-number { font-size: ${s(50)}; }
+  .screen--lg .view--full .flight-aircraft { font-size: ${s(22)}; }
+  .screen--lg .view--full .flight-status { font-size: ${s(27)}; }
+
   .flight-card { margin: ${variant === 'full' ? '0' : variant === 'half_vertical' ? `${s(12)} 0 0` : variant === 'half_horizontal' ? `${s(8)} 0` : `${s(6)} ${s(8)}`}; padding: ${variant === 'full' ? `${s(12)} ${s(24)}` : '0'}; font-family: 'IBM Plex Sans', 'SF Pro Text', 'Segoe UI', sans-serif; display: flex; flex-direction: column; flex: 1; }
   .flight-details { margin-top: ${variant === 'full' ? s(60) : '0'}; }
   .flight-top { display: flex; align-items: center; gap: ${variant === 'quadrant' ? s(12) : s(20)}; width: 100%; }

--- a/src/server.ts
+++ b/src/server.ts
@@ -126,11 +126,23 @@ const httpServer = server.listen(PORT, () => {
   logger.info('subspace API now listening on PORT:', config.api.port)
 })
 
-process.on('SIGTERM', () => {
-  logger.info('SIGTERM received, shutting down gracefully')
+/**
+ * Was having issues for the service taking too long to drain connections
+ * So we force stop after after a determinate amount of time
+ * @param signal The SIGXXX to intercept
+ */
+function shutdown(signal: string) {
+  logger.info(`${signal} received, shutting down gracefully`)
   httpServer.closeAllConnections()
   httpServer.close(() => {
     logger.info('Server closed')
     process.exit(0)
   })
-})
+  setTimeout(() => {
+    logger.warn('service took too long to shut down, killing...')
+    process.exit(1)
+  }, 8000).unref()
+}
+
+process.on('SIGTERM', () => shutdown('SIGTERM'))
+process.on('SIGINT', () => shutdown('SIGINT'))


### PR DESCRIPTION
## Summary
- **Graceful shutdown hardening** — `server.ts` gains a shutdown watchdog + `SIGINT` handler so a slow connection drain can't stall `docker stop` until SIGKILL (force-exit after 8s). `init: true` added to both compose files (tini as PID 1) as signal-forwarding insurance.
- **TRMNL X full card** — bigger airline logo + header fonts on the `screen--lg` full variant, now that centering freed vertical room.
- **Preview tooling** — `renderFlightPreview.ts` now also renders the X (`screen--lg`) variants.
- **CI** — `actions/checkout@v3→v5`, `docker/build-push-action@v5→v6` (clears the Node 20 deprecation warnings).
- Version bump to 1.17.5.

## Testing
- `npm run typecheck` clean
- `npm test` — 28/28 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)