### PR TITLE
Fix flight status showing 'Climbing' during descent (v1.17.8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subspace-api",
-  "version": "1.17.7",
+  "version": "1.17.8",
   "description": "API service for subtype.space",
   "repository": {
     "type": "git",

--- a/scripts/renderFlightPreview.ts
+++ b/scripts/renderFlightPreview.ts
@@ -1,7 +1,7 @@
 // This is a helper script to generate mock HTML representative of TRMNL devices.
 // It should generate all forms, including TRMNL X dimensions
 import { renderMarkup } from "../src/integrations/aerodatabox/formatters.js";
-import { writeFileSync } from "node:fs";
+import { writeFileSync } from "node:fs"; // ignore typecheck error, typelinting is fine via CI
 import { config } from '../src/config.js'
 import type { FlightDisplayData } from "../src/types/trmnl/flightTypes.js";
 import type { MarkupVariant } from "../src/integrations/aerodatabox/formatters.js";

--- a/src/integrations/aerodatabox/statusMapper.ts
+++ b/src/integrations/aerodatabox/statusMapper.ts
@@ -1,10 +1,17 @@
+// This module focuses on refining the flight metadata returned by the API
+// Do some more data massaging to produce a FlightDisplayData object that's passed back to the renderer.
 import type { AeroFlightContract, AeroFlightStatus, AeroLocation } from '../../types/aerodatabox/types.js'
 import type { FlightDisplayData } from '../../types/trmnl/flightTypes.js'
 import { calcProgress, formatHeading } from './formatters.js'
 
+// Past this point along the route, a low-altitude flight is descending toward
+// arrival rather than still climbing out of departure.
+const DESCENT_PROGRESS_THRESHOLD = 50
+
 // Resolve altitude in feet from location data.
 // The API sometimes returns feet=0 with a valid meter value, so we prefer
 // any non-zero value and convert meters as a fallback before trying pressureAltitude.
+// TODO: Expose a FT vs Meter preference in the settings UI
 function resolveAltFt(loc: AeroLocation): number | undefined {
   const fromAlt = loc.altitude?.feet || (loc.altitude?.meter != null ? loc.altitude.meter * 3.28084 : undefined)
   const fromPress =
@@ -51,9 +58,19 @@ function refineInFlightStatus(flight: AeroFlightContract): string {
 
   // On or near ground
   if (altFeet < 500) return 'On Ground'
-  // Below 10,000 ft and we have arrival airport — likely approaching or departing
+  // Below 10,000 ft — could be climbing out of departure or descending into arrival
+  // Use progress along route to determine which status to use
   if (altFeet < 10000) {
     if (flight.status === 'Approaching') return 'Descending'
+    const progress = calcProgress(
+      loc.lat,
+      loc.lon,
+      flight.departure.airport.location?.lat,
+      flight.departure.airport.location?.lon,
+      flight.arrival.airport.location?.lat,
+      flight.arrival.airport.location?.lon
+    )
+    if (progress != null) return progress >= DESCENT_PROGRESS_THRESHOLD ? 'Descending' : 'Climbing'
     return 'Climbing'
   }
   return 'Cruising'


### PR DESCRIPTION
## Summary
Fixes a regression where a flight's metadata status displayed **Climbing** when it was realistically descending toward arrival.

### Root cause
In `refineInFlightStatus` (`src/integrations/aerodatabox/statusMapper.ts`), a flight below 10,000 ft was only labeled `Descending` when the API's `flight.status` was literally `Approaching`. That flag lags — flights often stay `EnRoute`/`Departed` well into the descent — so a low-altitude aircraft near its destination got tagged `Climbing`.

### Fix
Below 10,000 ft (and not already `Approaching`), decide climb vs descent by route position via the existing `calcProgress` helper: past the halfway point (`DESCENT_PROGRESS_THRESHOLD = 50`) → `Descending`, before it → `Climbing`. Falls back to the prior `Climbing` default when position/airport coords are unavailable. Cruising (≥10k) and on-ground (<500 ft) logic untouched.

Also bumps version to **1.17.8**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)