### PR TITLE
Fix stale "Arriving" countdown on arrived flights (v1.18.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subspace-api",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "API service for subtype.space",
   "repository": {
     "type": "git",

--- a/scripts/renderFlightPreview.ts
+++ b/scripts/renderFlightPreview.ts
@@ -89,6 +89,24 @@ const scenarios: Scenario[] = [
     },
   },
   {
+    title: 'Arrived, no telemetry (ARRIVED landing time, not a stale "Arriving")',
+    flight: {
+      ...baseFlight,
+      status: 'Arrived',
+      altitudeFt: '--',
+      speedMph: '--',
+      heading: '--',
+      progressPct: 100,
+      minsRemaining: -312, // landed ~5h ago
+      depDelayMin: 13,
+      schedDep: '15:45',
+      depTime: '15:58',
+      delayMin: -56,
+      schedEta: '15:50',
+      eta: '14:54',
+    },
+  },
+  {
     title: 'Pre-flight, no live data (DEPARTS IN + TRIP)',
     flight: {
       ...baseFlight,

--- a/src/integrations/aerodatabox/renderer.ts
+++ b/src/integrations/aerodatabox/renderer.ts
@@ -15,6 +15,29 @@ function countdown(f: FlightDisplayData): { preDeparture: boolean; mins: number 
   return { preDeparture, mins: preDeparture ? f.minsToDeparture : f.minsRemaining }
 }
 
+// Terminal states: once the flight has landed the arrival countdown is meaningless
+// (it would read a stale "Arriving"), so the no-telemetry tile shows the landing instead.
+function isArrived(f: FlightDisplayData): boolean {
+  return f.status === 'Arrived' || f.status === 'Likely Arrived'
+}
+
+// The primary no-telemetry tile: departs-in / arrives-in while active, or the landed time once arrived.
+// `terse` picks the short labels (DEP IN / ARR IN) used on the space-constrained half variants.
+function progressTile(f: FlightDisplayData, terse: boolean): { label: string; value: string } {
+  if (isArrived(f)) {
+    return { label: 'ARRIVED', value: f.eta !== '--' ? escapeHtml(f.eta) : 'Landed' }
+  }
+  const countdownState = countdown(f)
+  const label = terse
+    ? countdownState.preDeparture
+      ? 'DEP IN'
+      : 'ARR IN'
+    : countdownState.preDeparture
+      ? 'DEPARTS IN'
+      : 'ARRIVING IN'
+  return { label, value: countdownState.mins != null ? escapeHtml(formatDuration(countdownState.mins)) : '--' }
+}
+
 /**
  * This is the main function that returns the HTML to a TRMNL device.
  * TRMNL requests that all variants are returned in the payload for all available markups.
@@ -159,7 +182,6 @@ function renderFullCard(f: FlightDisplayData, baseUrl: string): string {
   const hasFallback = f.minsToDeparture != null || f.minsRemaining != null || f.progressPct != null
   const depSched = wasAnchor(f.depDelayMin, f.schedDep)
   const arrSched = wasAnchor(f.delayMin, f.schedEta)
-  const cd = countdown(f)
   const baseTiles = hasLiveData
     ? [
         { label: 'ALT', value: altDisplay },
@@ -167,17 +189,14 @@ function renderFullCard(f: FlightDisplayData, baseUrl: string): string {
         { label: 'HDG', value: escapeHtml(f.heading) },
       ]
     : hasFallback
-      ? [
-          {
-            label: cd.preDeparture ? 'DEPARTS IN' : 'ARRIVING IN',
-            value: cd.mins != null ? escapeHtml(formatDuration(cd.mins)) : '--',
-          },
-          { label: 'TRIP', value: f.progressPct != null ? `${f.progressPct}%` : '--' },
-        ]
+      ? [progressTile(f, false), { label: 'TRIP', value: f.progressPct != null ? `${f.progressPct}%` : '--' }]
       : []
 
   const baseHtml = baseTiles
-    .map((t) => `<div class="stat-tile"><span class="stat-tile-label">${t.label}</span><span class="stat-tile-value">${t.value}</span></div>`)
+    .map(
+      (tile) =>
+        `<div class="stat-tile"><span class="stat-tile-label">${tile.label}</span><span class="stat-tile-value">${tile.value}</span></div>`
+    )
     .join('')
   // On-time verdict fills the (formerly V/S) 4th slot — a label-less status tile, shown whenever known.
   const statusHtml = f.delayString
@@ -251,7 +270,6 @@ function renderFlightCard(f: FlightDisplayData, variant: MarkupVariant, baseUrl:
   // Live telemetry with fallback to mins remaining and progress complete
   const hasLiveData = f.altitudeFt !== '--' || f.speedMph !== '--' || f.heading !== '--'
   const hasFallback = f.minsToDeparture != null || f.minsRemaining != null || f.progressPct != null
-  const cd = countdown(f)
   const aircraftStat =
     variant === 'half_horizontal' ? `<span class="stat-item flight-stat-aircraft">${escapeHtml(f.aircraftModel)}</span>` : ''
   const stat = (label: string, value: string) =>
@@ -263,8 +281,9 @@ function renderFlightCard(f: FlightDisplayData, variant: MarkupVariant, baseUrl:
       ${stat('SPD', `${escapeHtml(f.speedMph)}${f.speedMph !== '--' ? ' mph' : ''}`)}
       ${stat('HDG', escapeHtml(f.heading))}`
   } else if (hasFallback) {
+    const fallbackTile = progressTile(f, true)
     statsInner = `${aircraftStat}
-      ${stat(cd.preDeparture ? 'DEP IN' : 'ARR IN', cd.mins != null ? escapeHtml(formatDuration(cd.mins)) : '--')}
+      ${stat(fallbackTile.label, fallbackTile.value)}
       ${stat('TRIP', f.progressPct != null ? `${f.progressPct}%` : '--')}`
   } else {
     statsInner = aircraftStat

--- a/test/integrations/aerodatabox/renderers.test.ts
+++ b/test/integrations/aerodatabox/renderers.test.ts
@@ -207,6 +207,37 @@ describe('renderMarkup', () => {
     expect(halfPre).toContain('DEP IN:')
   })
 
+  it('shows ARRIVED (landing time) instead of a stale "Arriving" countdown once the flight has landed', () => {
+    // Regression: an Arrived flight has no telemetry but still carries progressPct/minsRemaining,
+    // so the fallback branch used to render "ARRIVING IN / Arriving" for a flight that landed hours ago.
+    const arrived = {
+      ...sampleFlight,
+      status: 'Arrived',
+      altitudeFt: '--',
+      speedMph: '--',
+      heading: '--',
+      progressPct: 100,
+      minsRemaining: -312, // arrived ~5h ago -> formatDuration would say "Arriving"
+      eta: '14:54',
+    }
+    const full = renderMarkup(arrived, 'full', 0, 'https://example.com')
+    expect(full).toContain('>ARRIVED<')
+    expect(full).toContain('>14:54<') // the actual landing time, not a countdown
+    expect(full).not.toContain('>ARRIVING IN<')
+    expect(full).not.toContain('>Arriving<')
+    expect(full).toContain('>TRIP<') // trip tile still shows completion alongside it
+
+    // half variants use the same terminal label, not the ARR IN countdown
+    const half = renderMarkup(arrived, 'half_horizontal', 0, 'https://example.com')
+    expect(half).toContain('ARRIVED:')
+    expect(half).not.toContain('ARR IN:')
+
+    // the inferred "Likely Arrived" state is treated the same
+    const likely = renderMarkup({ ...arrived, status: 'Likely Arrived' }, 'full', 0, 'https://example.com')
+    expect(likely).toContain('>ARRIVED<')
+    expect(likely).not.toContain('>Arriving<')
+  })
+
   it('escapes HTML in the last-updated label', () => {
     const out = renderMarkup({ ...sampleFlight, lastUpdated: '<script>' }, 'full', 0, 'https://example.com')
     expect(out).not.toContain('<script>')


### PR DESCRIPTION
## Summary
Patch fix for a regression where an **Arrived** flight (no live telemetry, but progressPct 100 / negative minsRemaining) rendered a stale `ARRIVING IN / Arriving` countdown tile.

- Add `isArrived()` + a shared `progressTile()` helper used by full and half variants; once landed the tile shows `ARRIVED` + the actual landing time.
- Regression test in `renderers.test.ts` (full + half + `Likely Arrived`).
- New "Arrived, no telemetry" preview scenario.
- Expanded a few shorthand locals (`cd` → `countdownState`, `pt` → `fallbackTile`).

50 tests pass, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)