### PR TITLE
Raise "was" anchor gate to 15 min (v1.18.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subspace-api",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "description": "API service for subtype.space",
   "repository": {
     "type": "git",

--- a/scripts/renderFlightPreview.ts
+++ b/scripts/renderFlightPreview.ts
@@ -35,13 +35,13 @@ const baseFlight: FlightDisplayData = {
 }
 
 // Each scenario exercises a different schedule/data state: the on-time verdict (15-min rule),
-// the "was" anchors (any deviation >2 min), and the no-telemetry fallback (departs-in / arrives-in).
+// the "was" anchors (notable deviations >15 min only), and the no-telemetry fallback (departs-in / arrives-in).
 // eta/depTime are the actual times; schedEta/schedDep are the originals. adherence is derived below.
 type Scenario = { title: string; flight: FlightDisplayData }
 const scenarios: Scenario[] = [
   { title: 'On time (0)', flight: { ...baseFlight, delayMin: 0, schedEta: '14:36' } },
   {
-    title: 'Minor delay, still "On time" — 12 min (anchors show, <15-min threshold)',
+    title: 'Minor delay — 12 min (On time, no anchor: under the 15-min gate)',
     flight: { ...baseFlight, depDelayMin: 12, schedDep: '08:00', delayMin: 12, schedEta: '14:24' },
   },
   {
@@ -57,8 +57,12 @@ const scenarios: Scenario[] = [
     flight: { ...baseFlight, delayMin: -22, schedEta: '14:58' },
   },
   {
-    title: 'Late departure, early arrival (was 07:58 / 14:58)',
-    flight: { ...baseFlight, depDelayMin: 14, schedDep: '07:58', delayMin: -22, schedEta: '14:58' },
+    title: 'Late departure (20), early arrival (22) — both notable, both anchor',
+    flight: { ...baseFlight, depDelayMin: 20, schedDep: '07:52', delayMin: -22, schedEta: '14:58' },
+  },
+  {
+    title: 'Departed 26 late, arriving 10 early — origin anchors, arrival under the gate (On time)',
+    flight: { ...baseFlight, depDelayMin: 26, schedDep: '07:46', depTime: '08:12', delayMin: -10, schedEta: '14:46', eta: '14:36' },
   },
   {
     title: 'Descending into SFO (near arrival)',

--- a/src/integrations/aerodatabox/renderer.ts
+++ b/src/integrations/aerodatabox/renderer.ts
@@ -3,10 +3,17 @@ import type { MarkupVariant } from '../../types/trmnl/types.js'
 import { escapeHtml } from '../../utils/html.js'
 import { buildArcSvg, formatDuration, planeSvg, AIRLINE_NAMES } from './formatters.js'
 
-// If a departure/arrival deviates more than +-2 minutes from schedule, show the original
-// scheduled time as a "was HH:MM" anchor next to the actual time. Returns '' otherwise.
+// Only surface the scheduled "was HH:MM" anchor for *notable* deviations. The actual time is
+// already shown, so a plane landing 2-14 min off schedule isn't worth an extra line — that's
+// detail, not glance. This 15-min bar matches the On-time/Delayed/Early adherence threshold, so
+// an anchor appears exactly when the flight is off-schedule enough to earn a verdict. Departure
+// and arrival are gated independently (a late pushback can anchor without the on-time arrival).
+const ANCHOR_MIN_DEVIATION_MIN = 15
+
 function wasAnchor(delayMin: number | null, schedTime: string): string {
-  return delayMin != null && Math.abs(delayMin) > 2 && schedTime !== '--' ? `was ${escapeHtml(schedTime)}` : ''
+  return delayMin != null && Math.abs(delayMin) > ANCHOR_MIN_DEVIATION_MIN && schedTime !== '--'
+    ? `was ${escapeHtml(schedTime)}`
+    : ''
 }
 
 // No-telemetry countdown: before wheels-up we count down to departure, after to arrival.

--- a/test/integrations/aerodatabox/renderers.test.ts
+++ b/test/integrations/aerodatabox/renderers.test.ts
@@ -61,13 +61,13 @@ describe('renderMarkup', () => {
   })
 
   it('full variant tiles carry only live telemetry (no delay tile); delay lives in the arc anchor', () => {
-    const out = renderMarkup({ ...sampleFlight, delayMin: 14, schedEta: '14:22' }, 'full', 0, 'https://example.com')
+    const out = renderMarkup({ ...sampleFlight, delayMin: 22, schedEta: '14:14' }, 'full', 0, 'https://example.com')
     expect(out).toContain('>ALT<')
     expect(out).toContain('>SPD<')
     expect(out).toContain('>HDG<')
     expect(out).not.toContain('>ARR<') // no delay tile
-    expect(out).not.toContain('14m late') // no worded delta
-    expect(out).toContain('was 14:22') // scheduled anchor on the arc
+    expect(out).not.toContain('22m late') // no worded delta
+    expect(out).toContain('was 14:14') // scheduled anchor on the arc (notable, >15 min)
   })
 
   it('falls back to derived time-left + trip tiles when there is no live telemetry (no row of --)', () => {
@@ -123,47 +123,51 @@ describe('renderMarkup', () => {
     expect(half).toContain('plane-icon') // inline SVG on the flat route line
   })
 
-  it('shows the scheduled "was" anchor (two absolute clocks) only when the flight deviates', () => {
+  it('shows the scheduled "was" anchor only for notable (>15 min) deviations, not minor ones', () => {
     // assert on the rendered anchor text, not the (always-present) .route-sched CSS rule
-    // late: actual 14:36, scheduled 14:22
-    const late = renderMarkup({ ...sampleFlight, delayMin: 14, schedEta: '14:22' }, 'half_vertical', 0, 'https://example.com')
-    expect(late).toContain('>was 14:22<')
-    expect(late).not.toContain('14m late') // no delta / no math
+    // notably late (22 min): anchor shows the original scheduled clock
+    const late = renderMarkup({ ...sampleFlight, delayMin: 22, schedEta: '14:14' }, 'half_vertical', 0, 'https://example.com')
+    expect(late).toContain('>was 14:14<')
+    expect(late).not.toContain('22m late') // no delta / no math
 
-    // early: actual 14:36, scheduled 14:48 — still an absolute clock, no negative delta / word
-    const early = renderMarkup({ ...sampleFlight, delayMin: -12, schedEta: '14:48' }, 'half_vertical', 0, 'https://example.com')
-    expect(early).toContain('>was 14:48<')
+    // notably early (20 min): still an absolute clock, no negative delta / word
+    const early = renderMarkup({ ...sampleFlight, delayMin: -20, schedEta: '14:56' }, 'half_vertical', 0, 'https://example.com')
+    expect(early).toContain('>was 14:56<')
     expect(early).not.toContain('early')
 
-    // on-time (within window): no anchor even though schedEta is present
-    const onTime = renderMarkup({ ...sampleFlight, delayMin: 1, schedEta: '14:35' }, 'half_vertical', 0, 'https://example.com')
-    expect(onTime).not.toContain('>was ')
+    // minor deviation within the 15-min window: no anchor (the actual time already carries it) —
+    // a plane landing 10 min off isn't worth an extra line on an at-a-glance display
+    const minorLate = renderMarkup({ ...sampleFlight, delayMin: 10, schedEta: '14:26' }, 'half_vertical', 0, 'https://example.com')
+    expect(minorLate).not.toContain('>was ')
+    const minorEarly = renderMarkup({ ...sampleFlight, delayMin: -12, schedEta: '14:48' }, 'half_vertical', 0, 'https://example.com')
+    expect(minorEarly).not.toContain('>was ')
+
     // unknown schedule: no anchor
     const unknown = renderMarkup({ ...sampleFlight, delayMin: null, schedEta: '--' }, 'half_vertical', 0, 'https://example.com')
     expect(unknown).not.toContain('>was ')
   })
 
-  it('anchors departure and arrival independently (a late pushback shows "was" under the origin)', () => {
-    // Departed 14 late, arrived on time (made up the time en route): only the origin gets an anchor.
-    const depLate = { ...sampleFlight, depDelayMin: 14, schedDep: '07:58', delayMin: 0, schedEta: '14:36' }
+  it('anchors departure and arrival independently (each gated on its own >15 min deviation)', () => {
+    // Departed 22 late, arrived on time (made up the time en route): only the origin gets an anchor.
+    const depLate = { ...sampleFlight, depDelayMin: 22, schedDep: '07:50', delayMin: 0, schedEta: '14:36' }
     const full = renderMarkup(depLate, 'full', 0, 'https://example.com')
-    expect(full).toContain('was 07:58') // origin anchor
+    expect(full).toContain('was 07:50') // origin anchor
     expect(full).not.toContain('was 14:36') // arrival on time -> no anchor
     const half = renderMarkup(depLate, 'half_vertical', 0, 'https://example.com')
-    expect(half).toContain('>was 07:58<')
+    expect(half).toContain('>was 07:50<')
 
-    // Both deviate -> both anchors render.
-    const both = { ...sampleFlight, depDelayMin: 14, schedDep: '07:58', delayMin: 14, schedEta: '14:22' }
+    // Both deviate notably -> both anchors render.
+    const both = { ...sampleFlight, depDelayMin: 22, schedDep: '07:50', delayMin: 22, schedEta: '14:14' }
     const bothOut = renderMarkup(both, 'half_vertical', 0, 'https://example.com')
-    expect(bothOut).toContain('>was 07:58<')
-    expect(bothOut).toContain('>was 14:22<')
+    expect(bothOut).toContain('>was 07:50<')
+    expect(bothOut).toContain('>was 14:14<')
 
-    // Opposite directions (late pushback, early arrival) both anchor — the "was" is an absolute
-    // clock, so the sign of each delay is irrelevant to the display.
-    const mixed = { ...sampleFlight, depDelayMin: 14, schedDep: '07:58', delayMin: -10, schedEta: '14:46' }
-    const mixedOut = renderMarkup(mixed, 'full', 0, 'https://example.com')
-    expect(mixedOut).toContain('was 07:58') // late departure
-    expect(mixedOut).toContain('was 14:46') // early arrival
+    // The screenshot case: pushed back 26 late but arrives only 10 early -> origin anchors, the
+    // in-window arrival does not (10 < 15), even though the departure deviation is notable.
+    const departedLateArrivedClose = { ...sampleFlight, depDelayMin: 26, schedDep: '07:46', delayMin: -10, schedEta: '14:46' }
+    const mixedOut = renderMarkup(departedLateArrivedClose, 'full', 0, 'https://example.com')
+    expect(mixedOut).toContain('was 07:46') // notable late departure
+    expect(mixedOut).not.toContain('was 14:46') // minor early arrival -> gated out
   })
 
   it('shows the on-time verdict as the 4th full-card tile (label-less), and hides it when unknown', () => {


### PR DESCRIPTION
## Summary
The actual dep/arrival time is already on the card, so a 2–14 min swing is detail, not glance. Raise the "was HH:MM" anchor threshold from 2 → **15 min** (`ANCHOR_MIN_DEVIATION_MIN`), matching the On-time/Delayed/Early adherence bar — an anchor now appears exactly when a flight is off-schedule enough to earn a verdict. Departure and arrival stay independently gated.

- `renderer.ts`: named 15-min constant, per-endpoint gating
- `renderers.test.ts`: notable-deviation anchor tests + assertions that minor (10–12 min) deviations show no anchor, incl. the one-sided screenshot case
- Preview: relabeled "minor delay" (now the calm/no-anchor state) + added the "departed 26 late, arriving 10 early" card

50 tests pass, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)