### PR TITLE
Move on-time verdict into header status line; drop 4th tile (v1.18.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subspace-api",
-  "version": "1.18.2",
+  "version": "1.18.3",
   "description": "API service for subtype.space",
   "repository": {
     "type": "git",

--- a/src/integrations/aerodatabox/renderer.ts
+++ b/src/integrations/aerodatabox/renderer.ts
@@ -99,9 +99,6 @@ export function renderMarkup(
   .stat-tile { flex: 1; border: ${s(2)} solid black; border-radius: ${s(10)}; padding: ${s(10)} ${s(6)}; display: flex; flex-direction: column; align-items: center; gap: ${s(3)}; }
   .stat-tile-label { font-size: ${s(15)}; font-weight: 700; letter-spacing: 1.5px; }
   .stat-tile-value { font-size: ${s(26)}; font-weight: 800; }
-  /* Arrival on-time verdict tile — no label, word centered + uppercased so it reads as a status flag. */
-  .stat-tile--status { justify-content: center; }
-  .stat-tile--status .stat-tile-value { text-transform: uppercase; letter-spacing: 0.5px; }
 
   /* TRMNL X (screen--lg): the taller screen leaves room to breathe, so center the
      blocks with a fixed gap (OG stays space-between — its content already fills the
@@ -205,11 +202,7 @@ function renderFullCard(f: FlightDisplayData, baseUrl: string): string {
         `<div class="stat-tile"><span class="stat-tile-label">${tile.label}</span><span class="stat-tile-value">${tile.value}</span></div>`
     )
     .join('')
-  // On-time verdict fills the (formerly V/S) 4th slot — a label-less status tile, shown whenever known.
-  const statusHtml = f.delayString
-    ? `<div class="stat-tile stat-tile--status"><span class="stat-tile-value">${escapeHtml(f.delayString)}</span></div>`
-    : ''
-  const tilesHtml = baseHtml + statusHtml
+  const tilesHtml = baseHtml
   const showTiles = tilesHtml !== ''
 
   return `
@@ -220,7 +213,7 @@ function renderFullCard(f: FlightDisplayData, baseUrl: string): string {
         <span class="airline-name">${escapeHtml(airlineName)}</span>
         <span class="flight-number">${escapeHtml(flightCode)}</span>
         <span class="flight-aircraft">${escapeHtml(f.aircraftModel)}</span>
-        <span class="flight-status">${escapeHtml(f.status)}</span>
+        <span class="flight-status">${escapeHtml(f.status)}${f.delayString ? ` <span class="flight-adherence">· ${escapeHtml(f.delayString)}</span>` : ''}</span>
       </div>
     </div>
     <div class="flight-arc-wrap">

--- a/test/integrations/aerodatabox/renderers.test.ts
+++ b/test/integrations/aerodatabox/renderers.test.ts
@@ -170,21 +170,22 @@ describe('renderMarkup', () => {
     expect(mixedOut).not.toContain('was 14:46') // minor early arrival -> gated out
   })
 
-  it('shows the on-time verdict as the 4th full-card tile (label-less), and hides it when unknown', () => {
-    // assert on the tile element, not the always-present .stat-tile--status CSS rule
+  it('shows the on-time verdict in the header status line (not a 4th tile), and hides it when unknown', () => {
     const delayed = renderMarkup({ ...sampleFlight, delayString: 'Delayed' }, 'full', 0, 'https://example.com')
-    expect(delayed).toContain('class="stat-tile stat-tile--status"')
-    expect(delayed).toContain('>Delayed<')
-    expect(delayed).toContain('>ALT<') // sits alongside the telemetry tiles
-    // unknown -> no status tile
+    // adherence rides in the header next to the flight phase, keeping the tile row a clean 3
+    expect(delayed).toContain('class="flight-adherence"')
+    expect(delayed).toContain('Delayed')
+    expect(delayed).not.toContain('stat-tile--status') // the old 4th tile is gone
+    expect(delayed).toContain('>ALT<') // uniform ALT/SPD/HDG telemetry row remains
+    // unknown -> no adherence in the header
     const unknown = renderMarkup({ ...sampleFlight, delayString: null }, 'full', 0, 'https://example.com')
-    expect(unknown).not.toContain('class="stat-tile stat-tile--status"')
+    expect(unknown).not.toContain('class="flight-adherence"')
   })
 
   it('does not surface delayString on half variants (the "was" anchors carry the delay there)', () => {
     const out = renderMarkup({ ...sampleFlight, delayString: 'Delayed' }, 'half_horizontal', 0, 'https://example.com')
-    expect(out).not.toContain('>Delayed<')
-    expect(out).not.toContain('class="stat-tile stat-tile--status"')
+    expect(out).not.toContain('flight-adherence')
+    expect(out).not.toContain('Delayed') // status is 'Cruising'; adherence never rendered on halves
   })
 
   it('counts down to departure (DEPARTS IN) pre-takeoff, then to arrival (ARRIVING IN)', () => {


### PR DESCRIPTION
## Summary
Feedback was that four stat tiles read busier than three. Fold the adherence verdict into the full card's header status line as **phase · verdict** (e.g. `Cruising · On time`, `Arrived · Early`) and return the tile row to a uniform `ALT / SPD / HDG` three.

- Full card only; half variants unchanged (still lean on `was …` anchors, never showed adherence)
- All `delayString` computation/suppression logic untouched — render-location change only
- Longest realistic pairing (`Descending · Delayed`) fits on one line, no wrap
- Removes dead `.stat-tile--status` CSS; renderer tests updated

50 tests pass, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)