### PR TITLE
Improve aeroClient caching and error handling

### DIFF
--- a/src/integrations/aerodatabox/aeroClient.ts
+++ b/src/integrations/aerodatabox/aeroClient.ts
@@ -31,6 +31,9 @@ export class AeroClient {
   private readonly ACTIVE_TTL_MS = 55 * 60 * 1000
   // Settled flights keep the same flight number until next day's operation — 4hr cache is safe
   private readonly SETTLED_TTL_MS = 4 * 60 * 60 * 1000
+  // if a flight number is not found, set the TTL to 55 minutes instead of 4 hours
+  // don't want to cache for 4 hours for something that COULD change into something real
+  private readonly NOT_FOUND_TTL_MS = 55 * 60 * 1000 
 
   // API queue system
   private readonly MIN_INTERVAL_MS = 1100
@@ -72,27 +75,54 @@ export class AeroClient {
     this.processing = false
   }
 
+  /**
+   * Get the appropriate cache TTL based on the flight status so we encourage the usage of the cache
+   * Active flights get a time to live of 55 minutes in the cache, while settled flights get a time to live of 4 hours
+   * 
+   * Caching null hits for a given flight number is also important to avoid repeated API calls for non-existent flights
+   * According to google - this is called negative caching
+   * 
+   * @param status AeroFlightStatus or null, representing the status of the flight
+   * @returns The time to live in milliseconds for the cache entry based on the flight status
+   */
   private getTtl(status: AeroFlightStatus | null): number {
     switch (status) {
       case 'Arrived':
       case 'Canceled':
-      case 'CanceledUncertain':
       case 'Diverted':
         return this.SETTLED_TTL_MS
+      case null:
+        return this.NOT_FOUND_TTL_MS
       default:
         return this.ACTIVE_TTL_MS
     }
   }
 
+  /**
+   * Flight lookup method using API
+   * @param flightNumber The flight number to perform an API call for a search
+   * @returns An AeroFlightContract object, an error if a search failed, or null if no flight was found
+   * 
+   * Note: This function is not cached, and will always perform an API call. Use getFlightByNumberCached() for caching.
+   * 
+   * @throws {Error} If the API call fails or returns an error response
+   */
   async getFlightByNumber(flightNumber: string): Promise<AeroFlightContract | null> {
     const url = `${this.provider.baseUrl}/flights/number/${encodeURIComponent(flightNumber)}?withLocation=true`
 
     return this.enqueue(async () => {
       logger.debug(`[AERO] GET ${url}`)
 
-      const res = await fetch(url, {
-        headers: this.provider.headers(this.apiKey),
-      })
+      let res: Response
+      try {
+        res = await fetch(url, {
+          headers: this.provider.headers(this.apiKey),
+          signal: AbortSignal.timeout(5000),
+        })
+      } catch (err) {
+        logger.warn(`[AERO] Flight lookup failed for ${flightNumber}: ${String(err)}`)
+        throw err
+      }
 
       if (res.status === 204) {
         logger.debug(`[AERO] No flights found for ${flightNumber}`)
@@ -101,7 +131,7 @@ export class AeroClient {
 
       if (!res.ok) {
         logger.warn(`[AERO] Flight lookup failed: ${res.status} ${res.statusText}`)
-        return null
+        throw new Error(`Flight lookup failed: ${res.status} ${res.statusText}`)
       }
 
       const flights = (await res.json()) as AeroFlightContract[]
@@ -117,6 +147,11 @@ export class AeroClient {
     })
   }
 
+  /**
+   * Flight lookup method using API with caching. Wraps around getFlightByNumber() to provide caching and inflight request deduplication
+   * @param flightNumber The flight number to perform an API search for
+   * @returns An AeroFlightContract or null - null cases are caught by the flightMarkupController
+   */
   async getFlightByNumberCached(flightNumber: string): Promise<AeroFlightContract | null> {
     logger.info(`[AERO] retrieving flight information for ${flightNumber}`)
     const now = Date.now()
@@ -150,6 +185,15 @@ export class AeroClient {
     return promise
   }
 
+  /**
+   * API can return an array of multiple AeroFlightContracts for the same flight number
+   * With different times, we filter out cargo flights, and choose the best flight based on the lastUpdated timestamp
+   * 
+   * This is used privately by getFlightByNumber() to pick the best flight from the API response and not used outside this class
+   * 
+   * @param flights An array of AeroFlightContract objects returned from the API for the same flight number
+   * @returns The best flight AeroFlightContract object, or null if no suitable flight was found
+   */
   private pickBestFlight(flights: AeroFlightContract[]): AeroFlightContract | null {
     const candidates = flights.filter((f) => !f.isCargo)
     if (candidates.length === 0) return null


### PR DESCRIPTION
## Summary
- Add negative caching (55min TTL) for flight-not-found lookups, separate from settled/active TTLs
- Treat `CanceledUncertain` as an active status instead of settled, since it usually means missing live data rather than a confirmed cancellation
- Add a 5s fetch timeout and surface HTTP/network failures as thrown errors instead of silently returning null
- Add JSDoc to the caching/lookup methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)